### PR TITLE
Issue #3: Add supported for CREATEDIR to CCCI FSD peripheral.

### DIFF
--- a/firmwire/vendor/mtk/hw/FSD.py
+++ b/firmwire/vendor/mtk/hw/FSD.py
@@ -1310,8 +1310,8 @@ class MTKFSD:
         if not self._is_dir(dirname):
             try:
                 os.makedirs(dirname)
-            except OSError as error:
-                self.log.error("creatdir: error %s", e)
+            except OSError as e:
+                self.log.error("createdir: error %s", e)
                 # TODO: real error codes
                 return FSError.GENERAL_FAILURE, []
         return FSError.NO_ERROR, []

--- a/firmwire/vendor/mtk/hw/FSD.py
+++ b/firmwire/vendor/mtk/hw/FSD.py
@@ -1306,7 +1306,6 @@ class MTKFSD:
 
     def _op_CREATEDIR(self, args):
         dirname = self._convert_path(args[0])
-        ret = FSError.GENERAL_FAILURE
 
         if not self._is_dir(dirname):
             try:

--- a/firmwire/vendor/mtk/hw/FSD.py
+++ b/firmwire/vendor/mtk/hw/FSD.py
@@ -1303,3 +1303,16 @@ class MTKFSD:
         self.log.warning("Restore: %s stub!", path)
 
         return FSError.NO_ERROR, []
+
+    def _op_CREATEDIR(self, args):
+        dirname = self._convert_path(args[0])
+        ret = FSError.GENERAL_FAILURE
+
+        if not self._is_dir(dirname):
+            try:
+                os.makedirs(dirname)
+            except OSError as error:
+                self.log.error("creatdir: error %s", e)
+                # TODO: real error codes
+                return FSError.GENERAL_FAILURE, []
+        return FSError.NO_ERROR, []


### PR DESCRIPTION
By implementing CREATEDIR, FirmWire will load an MTK image while using an empty directory for NV data.