### PR TITLE
Added Capability to build on M1 Mac (tested on MacOs 11.4) with docke…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
 LABEL "about"="FirmWire base img"
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Changed the Dockerfile to build on M1 Macs. It may also work on Linux machines without changes. Pls check.