### PR TITLE
 `qemu.protocols.execution` should not be shutted down for ShannonEMU

### DIFF
--- a/firmwire.py
+++ b/firmwire.py
@@ -179,6 +179,12 @@ def get_args():
         help="Replay a persistent-mode crash log written with --fuzz-crashlog-dir.",
     )
 
+    fuzzopts.add_argument(
+        "--keep-breakpoints-enabled",
+        action="store_true",
+        help="Always enable breakpoints by not shutting down the execution protocol",
+        )
+
     ### Loader args
 
     def fix_up_params(name, params):
@@ -388,7 +394,8 @@ def main() -> int:
         machine.print_task_list()
 
     log.info("Starting emulator %s", machine.instance_name)
-    machine.start(start_suspended=args.stop, console=args.console)
+    machine.start(start_suspended=args.stop, console=args.console, \
+        keep_exec=args.keep_breakpoints_enabled)
 
 
 if __name__ == "__main__":

--- a/firmwire/emulator/firmwire.py
+++ b/firmwire/emulator/firmwire.py
@@ -157,7 +157,7 @@ class FirmWireEmu(ABC):
 
         return True
 
-    def start(self, start_suspended=False, console=False):
+    def start(self, start_suspended=False, console=False, keep_exec=False):
         """Start the emulator"""
         assert self.qemu is not None
 
@@ -177,7 +177,7 @@ class FirmWireEmu(ABC):
                     qemu.protocols.monitor.shutdown()
                     # MTKEmu requires breakpoints (and hence, execution) to get to fuzzing,
                     # so we only shutdown execution in other cases
-                    if not "MtkEMU" in self.instance_name:
+                    if not "MtkEMU" in self.instance_name and not keep_exec:
                         qemu.protocols.execution.shutdown()
                 else:
                     qemu.cont()


### PR DESCRIPTION
`ShannonEMU` also requires breakpoint here.

https://github.com/FirmWire/FirmWire/blob/490163e6263edeebde11961d7b4a4f3690d5f4d0/firmwire/vendor/shannon/machine.py#L827

If `qemu.protocols.execution` is stopped, the execution will hang at breakpoint forever. This solves issue https://github.com/FirmWire/FirmWire/issues/26.