### PR TITLE
Update S3xxAPBoot.py

### DIFF
--- a/firmwire/vendor/shannon/hw/s3xxap.py
+++ b/firmwire/vendor/shannon/hw/s3xxap.py
@@ -25,7 +25,7 @@ class S3xxAPBoot(LoggingPeripheral):
         return super().hw_write(offset, size, value)
 
     def __init__(self, name, address, size, **kwargs):
-        super().__init__(name, address, size)
+        super().__init__(name, address, size, **kwargs)
 
         self.read_handler[0:size] = self.hw_read
         self.write_handler[0:size] = self.hw_write


### PR DESCRIPTION
Hi, 
     This pr fixed an error in the initialization of S3xxAPBoot to avoid exceptions during emulation of firmware such as Samsung Galaxy S6(or other S3xxAP device). It can support baseband CP_G960FXXU1ARC4 now.