### PR TITLE
Update machine.py

### DIFF
--- a/firmwire/vendor/shannon/machine.py
+++ b/firmwire/vendor/shannon/machine.py
@@ -461,7 +461,7 @@ r12: %08x     cpsr: %08x""" % (
             self.hook_debug()
             avatar.load_plugin("disassembler")
 
-        if args.fuzz_triage:
+        if args.fuzz_triage and args.fuzz_input:
             coverage_dir = self.workspace.path("/coverage")
             coverage_dir.mkdir()
 


### PR DESCRIPTION
Fix when using replay persistent crashlogs with `--fuzz-crashlog-replay`. When running command with this option, it cannot be set at the same time with option `--fuzz-input`.  So we should make sure to check if  `args.fuzz_input` is None  when trying to collect code coverage.