### PR TITLE
 Draft of multiple task injection feature for dev/1.2.0

### DIFF
--- a/firmwire.py
+++ b/firmwire.py
@@ -25,7 +25,6 @@ def get_args():
     print("                   https://github.com/FirmWire")
     print("")
 
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "modem_file", type=str, default=None, help="Modem file to emulate"
@@ -294,11 +293,12 @@ def main() -> int:
         # With shannon we can inject tasks overwriting the old one, even after snapshot restores for quick dev
         # NOTE: if you inject a task AFTER the task boot up phase it WILL NOT ever run. You will need
         # to use GLINK to dynamically register a task. GLINK would need have been loaded from the start in that case
-        asked_modules = [args.fuzz, args.fuzz_triage]
-        if ',' in args.injected_task:
-            args.injected_task = args.injected_task.split(',')
-        asked_modules.extend(list(args.injected_task))
-        for module_name in asked_modules:
+        injection_modules = [args.fuzz, args.fuzz_triage]
+        if type(args.injected_task) != type(None):
+            if ',' in args.injected_task:
+                args.injected_task = args.injected_task.split(',')
+            injection_modules.extend(list(args.injected_task))
+        for module_name in injection_modules:
             if module_name is None:
                 continue
             if not machine.load_and_inject_task(module_name):
@@ -312,5 +312,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
 

--- a/firmwire.py
+++ b/firmwire.py
@@ -16,13 +16,13 @@ from _version import __version__
 log = logging.getLogger("firmwire")
 
 def get_args():
-    print(r"              ___            __      _                          ")
-    print(r"-.     .-.   | __|(+) _ _ _ _\ \    / /(+) _ _ ___    .-.     .-")
+    print(r"              ___         __   _              ")
+    print(r"-.   .-.   | __|(+) _ _ _ _\ \    / /(+) _ _ ___  .-.    .-")
     print(r"  \   /   \  | _|  | | '_| '  \ \/\/ /  | | '_/ -_)  /   \   /  ")
-    print(r"   '-'     '-|_|   | |_| |_|_|_\_/\_/   | |_| \___|-'     '-'   ")
+    print(r"   '-'   '-|_|   | |_| |_|_|_\_/\_/   | |_| \___|-'    '-'   ")
     print(r"             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   v%s" % (__version__))
     print(r"                A  baseband  analysis  platform")
-    print("                   https://github.com/FirmWire")
+    print("       https://github.com/FirmWire")
     print("")
 
     parser = argparse.ArgumentParser()
@@ -291,16 +291,17 @@ def main() -> int:
 
     if loader.NAME == "shannon":
         # With shannon we can inject tasks overwriting the old one, even after snapshot restores for quick dev
-        # NOTE: if you inject a task AFTER the the task boot up phase it WILL NOT ever run. You will need
+        # NOTE: if you inject a task AFTER the task boot up phase it WILL NOT ever run. You will need
         # to use GLINK to dynamically register a task. GLINK would need have been loaded from the start in that case
-        for module_name in [args.injected_task, args.fuzz, args.fuzz_triage]:
+        asked_modules = [args.fuzz, args.fuzz_triage]
+        if ',' in args.injected_task:
+            args.injected_task = args.injected_task.split(',')
+        asked_modules.extend(list(args.injected_task))
+        for module_name in asked_modules:
             if module_name is None:
                 continue
-
             if not machine.load_and_inject_task(module_name):
-                return 1
-            else:
-                break
+                print("loaded task: " + module_name)
 
         machine.print_task_list()
 
@@ -310,3 +311,5 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+
+

--- a/firmwire.py
+++ b/firmwire.py
@@ -16,14 +16,15 @@ from _version import __version__
 log = logging.getLogger("firmwire")
 
 def get_args():
-    print(r"              ___         __   _              ")
-    print(r"-.   .-.   | __|(+) _ _ _ _\ \    / /(+) _ _ ___  .-.    .-")
+    print(r"              ___            __      _                          ")
+    print(r"-.     .-.   | __|(+) _ _ _ _\ \    / /(+) _ _ ___    .-.     .-")
     print(r"  \   /   \  | _|  | | '_| '  \ \/\/ /  | | '_/ -_)  /   \   /  ")
-    print(r"   '-'   '-|_|   | |_| |_|_|_\_/\_/   | |_| \___|-'    '-'   ")
+    print(r"   '-'     '-|_|   | |_| |_|_|_\_/\_/   | |_| \___|-'     '-'   ")
     print(r"             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   v%s" % (__version__))
     print(r"                A  baseband  analysis  platform")
-    print("       https://github.com/FirmWire")
+    print("                   https://github.com/FirmWire")
     print("")
+
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/firmwire.py
+++ b/firmwire.py
@@ -297,7 +297,9 @@ def main() -> int:
         if type(args.injected_task) != type(None):
             if ',' in args.injected_task:
                 args.injected_task = args.injected_task.split(',')
-            injection_modules.extend(list(args.injected_task))
+                injection_modules.extend(list(args.injected_task))
+            else:
+                injection_modules.append(args.injected_task)
         for module_name in injection_modules:
             if module_name is None:
                 continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ rocksdb
 cffi
 protobuf
 colorama
+unicorn==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,3 @@ rocksdb
 cffi
 protobuf
 colorama
-unicorn==2.1.0

--- a/tests/test_vendor_basic.py
+++ b/tests/test_vendor_basic.py
@@ -16,6 +16,7 @@ def setup():
     assert MTK_MODEM_FILE, SHANNON_MODEM_FILE
 
 def test_shannon_basic():
+    setup()
     workspace = firmwire.ScratchWorkspace()
     workspace.create()
 
@@ -34,6 +35,7 @@ def test_shannon_basic():
     machine.avatar.shutdown()
 
 def test_mtk_basic():
+    setup()
     workspace = firmwire.ScratchWorkspace()
     workspace.create()
     empty_nv = workspace.base_path() / "empty"


### PR DESCRIPTION
This PR is made to add to firmwire the ability to load more than one module with -t/--module option.

- As mentioned in the issue, I thought about adding flexibility to where the module could be mapped by firmwire. By looking at the code of machine.inject_task, I saw that the function does check if there is space available to inject/load the module. If you have any idea to add flexibility to this process, I can implement it.
- Corrected typo error
- Pull Request on branch dev/1.2.0

I don't think this is the cleanest way to do it, but it does work
I'm open to any recommendations

Best regards everyone
Lafreuxpabo
