### PR TITLE
Add --gsmtap feature, improve MTK FSD

### DIFF
--- a/firmwire.py
+++ b/firmwire.py
@@ -73,6 +73,10 @@ def get_args():
         help=f"Choose consecutive ports for the any listening sockets (e.g. QEMU's GDB & QMP), starting with the port provided.",
     )
 
+    parser.add_argument(
+        "--gsmtap", type=str, help="Stream packets from inside the baseband to this IP on port 4729 (gsmtap)"
+    )
+
     fuzzopts = parser.add_argument_group("fuzzing options")
 
     fuzzopts.add_argument(
@@ -288,6 +292,9 @@ def main() -> int:
 
     if args.gdb_server:
         machine.spawn_gdb_server(args.gdb_server)
+
+    if args.gsmtap:
+        machine.set_gsmtap_ip(args.gsmtap)
 
     if loader.NAME == "shannon":
         # With shannon we can inject tasks overwriting the old one, even after snapshot restores for quick dev

--- a/firmwire/emulator/firmwire.py
+++ b/firmwire/emulator/firmwire.py
@@ -47,6 +47,7 @@ class FirmWireEmu(ABC):
 
         self.signal_count = 0
         self.start_time = None
+        self._gsmtap_ip = None
 
     def set_breakpoint(self, address, handler, temporary=False, continue_after=False):
         """
@@ -715,3 +716,9 @@ class FirmWireEmu(ABC):
         self.qemu.cont()
         time.sleep(t)
         self.qemu.stop()
+
+    def set_gsmtap_ip(self, ip):
+        self._gsmtap_ip = ip
+
+    def get_gsmtap_ip(self):
+        return self._gsmtap_ip

--- a/firmwire/util/gsmtap.py
+++ b/firmwire/util/gsmtap.py
@@ -1,0 +1,246 @@
+## Copyright (c) 2025, Team FirmWire
+## SPDX-License-Identifier: BSD-3-Clause
+
+from enum import IntEnum, unique
+import struct
+import socket
+from firmwire.emulator.firmwire import FirmWireEmu
+
+# create_gsmtap_header from https://github.com/fgsect/scat/blob/master/src/scat/util.py
+# Struct definitions can be found in libosmocore's include/osmocom/core/gsmtap.h
+
+@unique
+class gsmtap_type(IntEnum):
+    UM = 0x01
+    ABIS = 0x02
+    UM_BURST = 0x03
+    SIM = 0x04
+    GB_LLC = 0x08
+    GB_SNDCP = 0x09
+    UMTS_RRC = 0x0C
+    LTE_RRC = 0x0D
+    LTE_MAC = 0x0E
+    LTE_MAC_FRAMED = 0x0F
+    OSMOCORE_LOG = 0x10
+    QC_DIAG = 0x11
+    LTE_NAS = 0x12
+
+
+@unique
+class gsmtap_channel(IntEnum):
+    UNKNOWN = 0x00
+    BCCH = 0x01
+    CCCH = 0x02
+    RACH = 0x03
+    AGCH = 0x04
+    PCH = 0x05
+    SDCCH = 0x06
+    SDCCH4 = 0x07
+    SDCCH8 = 0x08
+    TCH_F = 0x09
+    TCH_H = 0x0A
+    PACCH = 0x0B
+    CBCH52 = 0x0C
+    PDCH = 0x0D
+    PTCCH = 0x0E
+    CBCH51 = 0x0F
+
+
+@unique
+class gsmtap_umts_rrc_types(IntEnum):
+    DL_DCCH = 0
+    UL_DCCH = 1
+    DL_CCCH = 2
+    UL_CCCH = 3
+    PCCH = 4
+    DL_SHCCH = 5
+    UL_SHCCH = 6
+    BCCH_FACH = 7
+    BCCH_BCH = 8
+    MCCH = 9
+    MSCH = 10
+    HandoverToUTRANCommand = 11
+    InterRATHandoverInfo = 12
+    SystemInformation_BCH = 13
+    System_Information_Container = 14
+    UE_RadioAccessCapabilityInfo = 15
+    MasterInformationBlock = 16
+    SysInfoType1 = 17
+    SysInfoType2 = 18
+    SysInfoType3 = 19
+    SysInfoType4 = 20
+    SysInfoType5 = 21
+    SysInfoType5bis = 22
+    SysInfoType6 = 23
+    SysInfoType7 = 24
+    SysInfoType8 = 25
+    SysInfoType9 = 26
+    SysInfoType10 = 27
+    SysInfoType11 = 28
+    SysInfoType11bis = 29
+    SysInfoType12 = 30
+    SysInfoType13 = 31
+    SysInfoType13_1 = 32
+    SysInfoType13_2 = 33
+    SysInfoType13_3 = 34
+    SysInfoType13_4 = 35
+    SysInfoType14 = 36
+    SysInfoType15 = 37
+    SysInfoType15bis = 38
+    SysInfoType15_1 = 39
+    SysInfoType15_1bis = 40
+    SysInfoType15_2 = 41
+    SysInfoType15_2bis = 42
+    SysInfoType15_2ter = 43
+    SysInfoType15_3 = 44
+    SysInfoType15_3bis = 45
+    SysInfoType15_4 = 46
+    SysInfoType15_5 = 47
+    SysInfoType15_6 = 48
+    SysInfoType15_7 = 49
+    SysInfoType15_8 = 50
+    SysInfoType16 = 51
+    SysInfoType17 = 52
+    SysInfoType18 = 53
+    SysInfoType19 = 54
+    SysInfoType20 = 55
+    SysInfoType21 = 56
+    SysInfoType22 = 57
+    SysInfoTypeSB1 = 58
+    SysInfoTypeSB2 = 59
+    ToTargetRNC_Container = 60
+    TargetRNC_ToSourceRNC_Container = 61
+
+
+@unique
+class gsmtap_lte_rrc_types(IntEnum):
+    DL_CCCH = 0
+    DL_DCCH = 1
+    UL_CCCH = 2
+    UL_DCCH = 3
+    BCCH_BCH = 4
+    BCCH_DL_SCH = 5
+    PCCH = 6
+    MCCH = 7
+    BCCH_BCH_MBMS = 8
+    BCCH_DL_SCH_BR = 9
+    BCCH_DL_SCH_MBMS = 10
+    SC_MCCH = 11
+    SBCCH_SL_BCH = 12
+    SBCCH_SL_BCH_V2X = 13
+    DL_CCCH_NB = 14
+    DL_DCCH_NB = 15
+    UL_CCCH_NB = 16
+    UL_DCCH_NB = 17
+    BCCH_BCH_NB = 18
+    BCCH_BCH_TDD_NB = 19
+    BCCH_DL_SCH_NB = 20
+    PCCH_NB = 21
+    SC_MCCH_NB = 22
+
+
+def create_gsmtap_header(
+    version=2,
+    payload_type=0,
+    timeslot=0,
+    arfcn=0,
+    signal_dbm=0,
+    snr_db=0,
+    frame_number=0,
+    sub_type=0,
+    antenna_nr=0,
+    sub_slot=0,
+    device_sec=0,
+    device_usec=0,
+):
+    """
+    Create a GSMTAP header for the given parameters. To be used with send_gsmtap_packet.
+    The two relevant options are payload_type and sub_type, all other parameters can usually be left at their default values.
+    
+    Args:
+        version (int): GSMTAP version, either 2 or 3. Default is 2.
+        payload_type (gsmtap_type): The payload type, see gsmtap_type enum. Default is 0.
+        timeslot (int): GSM timeslot, default is 0.
+        arfcn (int): ARFCN, default is 0.
+        signal_dbm (int): Signal strength in dBm, default is 0.
+        snr_db (int): Signal to noise ratio, default is 0 (unknown).
+        frame_number (int): GSM frame number, default is 0.
+        sub_type (int): Subtype, meaning depends on payload_type, see, e.g., gsmtap_lte_rrc_types enum. Default is 0.
+        antenna_nr (int): Antenna number, default is 0.
+        sub_slot (int): Subslot, default is 0.
+        device_sec (int): Seconds part of the timestamp, only for version 3, default is 0.
+        device_usec (int): Microseconds part of the timestamp, only for version 3, default is 0.
+    """
+
+    gsmtap_v2_hdr_def = "!BBBBHBBLBBBB"
+    gsmtap_v3_hdr_def = "!BBBBHBBLBBBBQL"
+    gsmtap_hdr = b""
+
+    # Sanity check - Wireshark GSMTAP dissector accepts only 14 bits of ARFCN
+    # Only allow in GSM for implicitly marking uplink
+    if not (
+        payload_type == gsmtap_type.UM
+        or payload_type == gsmtap_type.UM_BURST
+        or payload_type == gsmtap_type.ABIS
+        or payload_type == gsmtap_type.GB_LLC
+        or payload_type == gsmtap_type.GB_SNDCP
+    ):
+        if arfcn < 0 or arfcn > (2**14 - 1):
+            arfcn = 0
+
+    if version == 2:
+        gsmtap_hdr = struct.pack(
+            gsmtap_v2_hdr_def,
+            2,  # Version
+            4,  # Header Length
+            payload_type,  # Type
+            timeslot,  # GSM Timeslot
+            arfcn,  # ARFCN
+            signal_dbm,  # Signal dBm
+            snr_db,  # SNR dB
+            frame_number,  # Frame Number
+            sub_type,  # Subtype
+            antenna_nr,  # Antenna Number
+            sub_slot,  # Subslot
+            0,  # Reserved
+        )
+    elif version == 3:
+        gsmtap_hdr = struct.pack(
+            gsmtap_v3_hdr_def,
+            3,  # Version
+            7,  # Header Length
+            payload_type,  # Type
+            timeslot,  # GSM Timeslot
+            arfcn,  # ARFCN
+            signal_dbm,  # Signal dBm
+            snr_db,  # SNR dB
+            frame_number,  # Frame Number
+            sub_type,  # Subtype
+            antenna_nr,  # Antenna Number
+            sub_slot,  # Subslot
+            0,  # Reserved
+            device_sec,
+            device_usec,
+        )
+    else:
+        assert (version == 2) or (
+            version == 3
+        ), "GSMTAP version should be either 2 or 3"
+
+    return gsmtap_hdr
+
+
+def send_gsmtap_packet(emu: FirmWireEmu, gsmtap_hdr: bytes, payload: bytes):
+    """
+    Send a GSMTAP packet to the configured IP address in the emulator.
+    If no IP address is configured, the packet is not sent.
+
+    Args:
+        emu (FirmWireEmu): The FirmWire emulator instance.
+        gsmtap_hdr (bytes): GSMTAP header, can be initialized via create_gsmtap_header
+        payload (bytes): The raw payload to send, e.g., a RRC message.
+    """
+    ip = emu.get_gsmtap_ip()
+    if ip is not None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(gsmtap_hdr + payload, (ip, 4729))

--- a/firmwire/vendor/mtk/hooks.py
+++ b/firmwire/vendor/mtk/hooks.py
@@ -3,6 +3,13 @@
 import struct
 import logging
 
+from firmwire.util.gsmtap import (
+    gsmtap_type,
+    gsmtap_lte_rrc_types,
+    send_gsmtap_packet,
+    create_gsmtap_header,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -188,3 +195,88 @@ def TCC_Task_Ready_To_Scheduled_Return(self, env, tb, hook):
     task = self.qemu.pypanda.arch.get_reg(env, "s1")
     if task != 0:
         self._current_task_name = self.read_phy_string(task + 0x10).decode()
+
+def msg_send_hook(self, env, tb, param3):
+    ra = self.qemu.pypanda.arch.get_reg(env, "ra")
+    struct_addr = self.qemu.pypanda.arch.get_reg(env, "a0")
+    src_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(struct_addr, 2), "little"
+    )
+    dest_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(struct_addr + 2, 2), "little"
+    )
+    msg_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(struct_addr + 6, 2), "little"
+    )
+    self.guest_logger.log_emit(
+        "msg_send: Sender %04X -> Receiver %04X ID: %s (%04X)",
+        src_id,
+        dest_id,
+        self.loader.msg_names.get(msg_id, "?"),
+        msg_id,
+        task_name=self._current_task_name,
+        address=ra,
+    )
+    if msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ"]:
+        gsmtap_uplink_errc_dcch_data(self, env, struct_addr)
+    elif msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_IND"]:
+        gsmtap_downlink_errc_dcch_data(self, env, struct_addr)
+
+
+def gsmtap_uplink_errc_dcch_data(self, cpu, msg_struct_addr):
+    """
+        Parser for MSG_ID_RATDM_EPDCP_DATA_REQ
+    """
+    expected_msg_id = self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ"]
+
+    msg_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 6, 2), "little"
+    )
+    assert (
+        msg_id == expected_msg_id
+    ), f"Tried to extract a data buffer from wong ilm msg type (is: ${msg_id}, expected: MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ (${expected_msg_id}))"
+    log.info(f"Forwarding DCCH-UL packet via GSMTAP")
+    local_para_ptr = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 8, 4), "little"
+    )
+    data_ptr = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(local_para_ptr + 12, 4), "little"
+    )
+    data_len = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(local_para_ptr + 16, 4), "little"
+    )
+    gsmtap_hdr = create_gsmtap_header(
+        payload_type=gsmtap_type.LTE_RRC, sub_type=gsmtap_lte_rrc_types.UL_DCCH
+    )
+    send_gsmtap_packet(
+        self, gsmtap_hdr, self.qemu.pypanda.physical_memory_read(data_ptr, data_len)
+    )
+
+
+def gsmtap_downlink_errc_dcch_data(self, cpu, msg_struct_addr):
+    """
+        Parser for MSG_ID_ERRC_EPDCP_DCCH_DATA_IND
+    """
+    expected_msg_id = self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_IND"]
+    msg_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 6, 2), "little"
+    )
+    assert (
+        msg_id == expected_msg_id
+    ), f"Tried to extract a data buffer from wong ilm msg type (is: ${msg_id}, expected: MSG_ID_ERRC_EPDCP_DCCH_DATA_IND (${expected_msg_id}))"
+    log.info(f"Forwarding DCCH-DL packet via GSMTAP")
+    local_para_ptr = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 8, 4), "little"
+    )
+    data_ptr = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(local_para_ptr + 16, 4), "little"
+    )
+    data_len = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(local_para_ptr + 20, 4), "little"
+    )
+    gsmtap_hdr = create_gsmtap_header(
+        payload_type=gsmtap_type.LTE_RRC, sub_type=gsmtap_lte_rrc_types.DL_DCCH
+    )
+    send_gsmtap_packet(
+        self, gsmtap_hdr, self.qemu.pypanda.physical_memory_read(data_ptr, data_len)
+    )

--- a/firmwire/vendor/mtk/hw/FSD.py
+++ b/firmwire/vendor/mtk/hw/FSD.py
@@ -579,21 +579,27 @@ class MTKFSD:
             resp_buf += struct.pack("I", len(p))
             resp_buf += p + b"\x00" * (len(p) % 4)
 
-        # TODO: fragment outbound packets
-        assert len(resp_buf) <= MAX_FS_PKT_BYTE, "Unhandled output packet requirement"
+        bytes_written = 0
+        out_packets = []
 
-        ccci_header = struct.pack(
-            "5I",
-            data0 & ~CCCI_FRAGMENT,
-            len(resp_buf) + 0x14,
-            channel + 1,
-            reqBuf,
-            op | FS_API_RESP_ID,
-        )
+        while bytes_written < len(resp_buf):
+            must_fragment = (len(resp_buf) - bytes_written) > MAX_FS_PKT_BYTE
+            fragment_size = min(len(resp_buf) - bytes_written, MAX_FS_PKT_BYTE)
 
-        resp_buf = ccci_header + resp_buf
+            ccci_header = struct.pack(
+                "5I",
+                (data0 | CCCI_FRAGMENT) if must_fragment else (data0 & ~CCCI_FRAGMENT),
+                fragment_size + 0x14,
+                channel + 1,
+                reqBuf,
+                op | FS_API_RESP_ID,
+            )
 
-        return resp_buf
+            packet = ccci_header + resp_buf[bytes_written:(bytes_written+fragment_size)]
+            out_packets.append(packet)
+            bytes_written += fragment_size
+
+        return out_packets
 
     def _handle_op(self, op_int, args):
         ret = 0

--- a/firmwire/vendor/mtk/hw/PCCIFPeripheral.py
+++ b/firmwire/vendor/mtk/hw/PCCIFPeripheral.py
@@ -607,8 +607,9 @@ class PCCIF_Periph(PassthroughPeripheral):
         )
 
         # if no data was returned, don't write anything
-        if len(emu_resp):
-            ring.writePacket(emu_resp)
+        for fragment in emu_resp:
+            if len(fragment):
+                ring.writePacket(fragment)
 
     def _handleFSPacketCompare(self, ring, buff):
         # only this will write to the guest

--- a/firmwire/vendor/mtk/loader.py
+++ b/firmwire/vendor/mtk/loader.py
@@ -157,6 +157,10 @@ class MTKLoader(firmwire.loader.Loader):
         else:
             log.info("Loaded database with %d trace entries", len(parsed_lted["trace"]))
             self.trace_entries = parsed_lted["trace"]
+            msg_enum_lists = [enums for (name, enums) in parsed_lted["enum"].items() if name.startswith("__cgen_msg_type_id")]
+            msg_enums = [entries for (metadata, entries) in msg_enum_lists]
+            self.msg_ids = { v: k for y in msg_enums for (k, v) in y.items() } # Maps message names to their IDs
+            self.msg_names = { v: k for (k, v) in self.msg_ids.items() } # Maps the message IDs to their names
 
         # Check to see if NV data is available
         nv_data_path = self.loader_args["nv_data"]

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -19,6 +19,7 @@ from firmwire.vendor.mtk.hooks import (
     prompt_trace_hook,
     sys_trace_hook,
     NU_Set_Events_hook,
+    msg_send_hook
 )
 from firmwire.vendor.mtk.mtk_task import MtkTask, TASK_STRUCT_SIZE
 
@@ -586,6 +587,8 @@ class MT6878Machine(FirmWireEmu):
                 symbols["TCC_Task_Ready_To_Scheduled_Return"],
                 TCC_Task_Ready_To_Scheduled_Return,
             )
+            self.add_panda_hook(symbols["msg_send"], msg_send_hook)
+            self.add_panda_hook(symbols["msg_send_adt"], msg_send_hook)
 
             """
             def buffer_print_hook(self, env, tb, hook):

--- a/modkit/common/ota_data.h
+++ b/modkit/common/ota_data.h
@@ -1,0 +1,7 @@
+typedef enum DlControlChannelsLte {
+    MCCH = 0,
+    CCCH = 1,
+    DCCH = 2,
+    BCCH_DL_SCH = 3
+} DlControlChannelsLte_t;
+#define DlControlChannelsLteCount 4

--- a/modkit/mtk/Makefile
+++ b/modkit/mtk/Makefile
@@ -27,6 +27,7 @@ CFLAGS=-march=interaptiv \
        -std=gnu99 \
        -fpie \
        -I $(CURDIR) \
+	   -I $(CURDIR)/../common \
        -Wall \
        -Wextra \
        -nostdlib \
@@ -39,6 +40,10 @@ CFLAGS=-march=interaptiv \
        -Wno-unused-parameter \
 	-Wl,--build-id=none \
 	   -Wl,--require-defined=TASK_NAME
+
+ifdef ASSUME_CONNECTED_STATE
+CFLAGS += -DASSUME_CONNECTED_STATE
+endif
 
 ASFLAGS=
 DEPFLAGS=-M $(CFLAGS)

--- a/modkit/mtk/afl.c
+++ b/modkit/mtk/afl.c
@@ -6,6 +6,7 @@
 #include <modkit.h>
 //#include <hello_world.h>
 #include "afl.h"
+#include "common.h"
 
 MODKIT_FUNCTION_SYMBOL(void, dhl_print_string, int, int, int, char *)
 MODKIT_FUNCTION_SYMBOL(int, kal_get_task_by_moduleID, int)

--- a/modkit/mtk/fuzzers/lte_rrc.c
+++ b/modkit/mtk/fuzzers/lte_rrc.c
@@ -3,9 +3,9 @@
 #include <afl.h>
 #include "common.h"
 #include "mtk_api.h"
+#include "ota_data.h"
 
 //#define DEBUG_PRINTS
-
 #define PARA_STRUCT_SIZE 0xc
 #define PARA_STRUCT_PLSIZE (PARA_STRUCT_SIZE-4)
 
@@ -55,7 +55,6 @@ char *asn_pl;
 
 int fuzz_single_setup()
 {
-    const char nops[4] = "\x00\x65\x00\x65";
     const char jrcnop[4] = "\xa0\xe8\x00\x65";
 
     // output version for debugging
@@ -90,10 +89,15 @@ int fuzz_single_setup()
     memcpy(errc_asn1_mem_free, jrcnop, 4);
 
     // 3 is likely ERRC_CONNECTED or LTE_RRC_STATE_CONNECTED?
+#ifdef ASSUME_CONNECTED_STATE
+    #ifdef DEBUG_PRINTS
+        dhl_print_string(2, 0, 0, "[+] Patching state");
+    #endif
     errc_set_current_errc_sim_idx_cntx_ptr(0);
     errc_spv_write_errc_state(3);
     errc_set_current_errc_sim_idx_cntx_ptr(1);
     errc_spv_write_errc_state(3);
+#endif
 
     return 1;
 }
@@ -135,18 +139,6 @@ void fuzz_single()
     }
     input_size = size - 1;
 
-#if 0
-    char *asn_pl;
-    unsigned int prbm_alloc_size = 0;
-    if (buf[0] == 0x4a)
-        prbm_alloc_size = input_size + 4;
-    else if (buf[0] != 0x47)
-        prbm_alloc_size = input_size;
-
-    if (prbm_alloc_size != 0)
-        asn_pl = prbm_allocate(input_size, 1);
-    //char *asn_pl = (void *)0x50000000;
-#endif
     memset(asn_pl, 0, 0x200);
 
     unsigned int my_num;
@@ -154,13 +146,16 @@ void fuzz_single()
 #ifdef DEBUG_PRINTS
     dhl_print_string(2, 0, 0, "[+] calling alloc_local_para\n");
 #endif
-    switch (buf[0]) {
-    case 0x53: // MCCH
+
+    DlControlChannelsLte_t input_type = buf[0] % DlControlChannelsLteCount;
+
+    switch (input_type) {
+    case MCCH: // MCCH
         _local_para_ptr = alloc_local_para(0x8 + 0x8);
         memcpy(((char *)_local_para_ptr) + 0x8, &asn_pl, 4);
         memcpy(((char *)_local_para_ptr) + 0xc, &input_size, 4);
         break;
-    case 0x4a: // DL_DCCH
+    case DCCH: // DL_DCCH
         _local_para_ptr = alloc_local_para(0x8 + 0x10);
         memcpy(((char *)_local_para_ptr) + 0x10, &asn_pl, 4);
         my_num = input_size + 4; // last 4 bytes are something else, there's a memcmp /after/ asn1 parsing
@@ -168,12 +163,12 @@ void fuzz_single()
         my_num = 2; // 2 seems to be active state?
         memcpy(((char *)_local_para_ptr) + 0x8, &my_num, 4);
         break;
-    case 0x49: // DL_CCCH
+    case CCCH: // DL_CCCH
         _local_para_ptr = alloc_local_para(0x8 + 0x4);
         memcpy(((char *)_local_para_ptr) + 0x4, &asn_pl, 4); // FIXME: this can't be right...???
         memcpy(((char *)_local_para_ptr) + 0x8, &input_size, 4);
         break;
-    case 0x47: // BCCH_DL_SCH
+    case BCCH_DL_SCH: // BCCH_DL_SCH
         _local_para_ptr = alloc_local_para(0x8 + 0x10);
 
         // get through checks in errc_lsys_main
@@ -211,8 +206,8 @@ void fuzz_single()
 #endif
     startWork(0, 0xffffffff); // memory range to collect coverage
 
-    switch (buf[0]) {
-    case 0x53:
+    switch (input_type) {
+    case MCCH:
 //#define MCCH_FOR_A10s
 #ifdef MCCH_FOR_A10s
         // early builds:
@@ -224,13 +219,13 @@ void fuzz_single()
         msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, MSG_ID_MCCH, _local_para_ptr, _peer_buff_ptr);
 #endif
         break;
-    case 0x4a:
+    case DCCH:
         msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, MSG_ID_DCCH, _local_para_ptr, _peer_buff_ptr);
         break;
-    case 0x49:
+    case CCCH:
         msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, MSG_ID_CCCH, _local_para_ptr, _peer_buff_ptr);
         break;
-    case 0x47:
+    case BCCH_DL_SCH:
         // setting the source module to 0x4b avoids double-free in destroy_int_ilm, let's not ask too many questions
         msg_send6(0x4b, TASK_ID_ERRC, 0, MSG_ID_BCCH, _local_para_ptr, _peer_buff_ptr);
         break;


### PR DESCRIPTION
This PR contains 3 related but distinct features:
- It fixes a bug in the MTK FSD that did not implement packet fragmentation (breaking compat to Samsung A41 SPL May 2022)
- It adds some flags to the `LTE_RRC` task to disable state patching
- It adds a feature to extract packets from and to the emulator via the `--gsmtap` flag (currently only supports LTE DCCH for MTK, Samsung coming soon). Effectively, this means that you can hook up Wireshark to the emulated process and watch it react to DL messages with UL responses. For the UL responses to appear, you will need state recovery (e.g. via BaseBridge). But even if you are just able to see the DL messages, that is already quite neat to triage crashes.