### PR TITLE
mtk: Add memory recovery from physical crash dumps

### DIFF
--- a/firmwire.py
+++ b/firmwire.py
@@ -77,6 +77,8 @@ def get_args():
         "--gsmtap", type=str, help="Stream packets from inside the baseband to this IP on port 4729 (gsmtap)"
     )
 
+    parser.add_argument_group
+
     fuzzopts = parser.add_argument_group("fuzzing options")
 
     fuzzopts.add_argument(
@@ -178,6 +180,28 @@ def get_args():
         help="Enable *full* coverage collection (logs every executed basic block)",
     )
 
+    # Memory dump options (must be all set or none)
+    mem_group = parser.add_argument_group("memory dump options", description=
+                                          "Options to load a memory dump into the emulated machine at a specific point. All three options must be provided to enable this feature.")
+    mem_group.add_argument(
+        "--mem-dump",
+        type=str,
+        default=None,
+        help="Path to memory dump file to load",
+    )
+    mem_group.add_argument(
+        "--load-mem-dump-at",
+        type=str,
+        default=None,
+        help="PC Address (hex) or symbol name when to load the memory dump",
+    )
+    mem_group.add_argument(
+        "--mem-dump-addrs",
+        type=str,
+        default=None,
+        help="Path to file listing addresses and lengths (one per line: <addr>,<len>)",
+    )
+
     ### Parse
     args = parser.parse_args()
 
@@ -191,6 +215,59 @@ def get_args():
 
     for name, validator in loader_specific_args.items():
         loader_specific_args[name] = validator.extract_relevant_params(args)
+
+    # Validate memory-dump options: either all provided or none
+    if args.mem_dump is not None or args.load_mem_dump_at is not None or args.mem_dump_addrs is not None:
+        if args.mem_dump is None or args.load_mem_dump_at is None or args.mem_dump_addrs is None:
+            parser.error(
+                "Options --mem-dump, --load-mem-dump-at and --mem-dump-addrs must be all set or none set"
+            )
+
+    # If provided, validate --mem-dump exists
+    if args.mem_dump is not None:
+        if not os.path.isfile(args.mem_dump):
+            parser.error(f"--mem-dump file does not exist: {args.mem_dump}")
+
+        # Parse the mem-dump-addrs file into a list of (addr, length) tuples
+        addrs_list = []
+        try:
+            with open(args.mem_dump_addrs, "r") as f:
+                for lineno, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = [p.strip() for p in line.split(",")]
+                    if len(parts) != 2:
+                        parser.error(
+                            f"Invalid line in --mem-dump-addrs at {args.mem_dump_addrs}:{lineno}: '{line}' (expected 'addr,length')"
+                        )
+                    try:
+                        addr = int(parts[0], 0)
+                        length = int(parts[1], 0)
+                    except Exception as e:
+                        parser.error(
+                            f"Invalid numeric value in --mem-dump-addrs at {args.mem_dump_addrs}:{lineno}: {e}"
+                        )
+                    if length <= 0:
+                        parser.error(
+                            f"Length must be positive in --mem-dump-addrs at {args.mem_dump_addrs}:{lineno}"
+                        )
+                    addrs_list.append((addr, length))
+        except FileNotFoundError:
+            parser.error(f"--mem-dump-addrs file does not exist: {args.mem_dump_addrs}")
+        except Exception as e:
+            parser.error(f"Failed to read --mem-dump-addrs: {e}")
+
+        args.mem_dump_addrs = addrs_list
+
+        # Parse --load-mem-dump-at: try numeric parse, otherwise leave as symbol string
+        s = args.load_mem_dump_at
+        try:
+            args.load_mem_dump_at = int(s, 0)
+        except Exception:
+            # keep as symbol name (string)
+            pass
+
 
     return args, loader_specific_args, params
 
@@ -295,6 +372,13 @@ def main() -> int:
 
     if args.gsmtap:
         machine.set_gsmtap_ip(args.gsmtap)
+
+    if args.mem_dump:
+        machine.configure_memory_dump(
+            dump_file=args.mem_dump,
+            load_at=args.load_mem_dump_at,
+            addrs=args.mem_dump_addrs,
+        )
 
     if loader.NAME == "shannon":
         # With shannon we can inject tasks overwriting the old one, even after snapshot restores for quick dev

--- a/firmwire/emulator/firmwire.py
+++ b/firmwire/emulator/firmwire.py
@@ -48,6 +48,7 @@ class FirmWireEmu(ABC):
         self.signal_count = 0
         self.start_time = None
         self._gsmtap_ip = None
+        self._mem_dump_config = { "dump_file": None, "load_at": None, "load_after_snapshot": False, "addrs": None, "enabled": False }
 
     def set_breakpoint(self, address, handler, temporary=False, continue_after=False):
         """
@@ -287,6 +288,9 @@ class FirmWireEmu(ABC):
             self.remove_breakpoint(bid)
 
         assert len(self._bp_map) == 0
+        
+        if self.is_memory_dump_to_be_restored_on_snapshot():
+            self.restore_memory_dump()
 
         breakpoints = machine_state["breakpoints"]
 
@@ -722,3 +726,59 @@ class FirmWireEmu(ABC):
 
     def get_gsmtap_ip(self):
         return self._gsmtap_ip
+    
+    def configure_memory_dump(self, dump_file, load_at, addrs):
+        """Configure memory dump loading options"""
+        self._mem_dump_config["dump_file"] = dump_file
+        self._mem_dump_config["addrs"] = addrs
+        self._mem_dump_config["enabled"] = True
+
+        if load_at == "SNAPSHOT_RESTORE":
+            self._mem_dump_config["load_after_snapshot"] = True
+            return
+            
+        if isinstance(load_at, str):
+            #sym = self.symbol_table.lookup(load_at)
+            sym = self.symbols.get(load_at, None)
+            if sym is None:
+                log.error(
+                    f"Unable to find symbol {load_at} for memory dump restore"
+                )
+                raise RuntimeError("Memory dump configuration failure")
+            else:
+                self._mem_dump_config["load_at"] = sym
+        else:
+            self._mem_dump_config["load_at"] = load_at
+
+        self.load_memory_dump()
+        self.set_breakpoint(self._mem_dump_config["load_at"], self.mem_dump_load_hook, continue_after=True, temporary=True)
+
+    def is_memory_dump_enabled(self):
+        """Check if memory dump loading is enabled"""
+        return self._mem_dump_config["enabled"]
+
+    def is_memory_dump_to_be_restored_on_snapshot(self):
+        """Check if memory dump loading is configured to occur after snapshot restore"""
+        return self._mem_dump_config["load_after_snapshot"]
+
+    def get_memory_dump_file_path(self):
+        """Get the memory dump file path"""
+        return self._mem_dump_config["dump_file"]
+
+    def get_mem_dump_addrs(self):
+        """Get the memory dump addresses configuration"""
+        return self._mem_dump_config["addrs"]
+
+    def mem_dump_load_hook(self):
+        if not self._mem_dump_config["enabled"]:
+            log.debug("Memory dump loading not enabled, skipping hook")
+            return
+        self.restore_memory_dump()
+
+    def load_memory_dump(self):
+        """Overrideable function to load a memory dump for later restoring. Called during configuration."""
+        pass
+
+    def restore_memory_dump(self):
+        """Overrideable function to restore a memory dump. Called once the recovery breakpoint is hit or during snapshot restore, if requested."""
+        raise Exception("Memory dump loading not implemented for current machine")

--- a/firmwire/vendor/mtk/consts.py
+++ b/firmwire/vendor/mtk/consts.py
@@ -141,12 +141,7 @@ TASKNAMES_DEACTIVATED = [
     # 2G/3G
     "MRF",
     # LTE
-    "ERT",
     "EMACDL",
-    "EL2H",
-    "EL2",
-    "EL1",
-    "EL1_MPC",
     "MLL1",
     # Middle ware
     "AUDIO",

--- a/firmwire/vendor/mtk/hooks.py
+++ b/firmwire/vendor/mtk/hooks.py
@@ -217,10 +217,11 @@ def msg_send_hook(self, env, tb, param3):
         task_name=self._current_task_name,
         address=ra,
     )
-    if msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ"]:
-        gsmtap_uplink_errc_dcch_data(self, env, struct_addr)
-    elif msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_IND"]:
-        gsmtap_downlink_errc_dcch_data(self, env, struct_addr)
+    if self.get_gsmtap_ip() is not None:
+        if msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ"]:
+            gsmtap_uplink_errc_dcch_data(self, env, struct_addr)
+        elif msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_IND"]:
+            gsmtap_downlink_errc_dcch_data(self, env, struct_addr)
 
 
 def gsmtap_uplink_errc_dcch_data(self, cpu, msg_struct_addr):

--- a/firmwire/vendor/mtk/hw/PCCIFPeripheral.py
+++ b/firmwire/vendor/mtk/hw/PCCIFPeripheral.py
@@ -481,11 +481,21 @@ class PCCIF_Periph(PassthroughPeripheral):
                 assert value == 0
                 self.handleAMMS()
                 return True
-            if value == 15:  # TODO: should prbly be >=15
+            if value == 15:
                 # RINGQ_SRAM
                 self.handle_SRAM_write()
-            else:
-                if value >= len(self.ringbuffer.offsets):
+            else: # drivers/misc/mediatek/eccci/mt6768/ccif_hif_platform.h
+                if value >= 16 and value <= 19:
+                    self.log.error(
+                        f"CCCI Received D2H exception ({value})"
+                    )
+                    assert False
+                elif value == 21:
+                    self.log.error(
+                        f"CCCI Received AP MD SEQ error"
+                    )
+                    assert False
+                elif value >= len(self.ringbuffer.offsets):
                     self.log.error(
                         f"PCCIF ring no too large (value: {value}, is only: {len(self.ringbuffer.offsets)})"
                     )

--- a/firmwire/vendor/mtk/loader.py
+++ b/firmwire/vendor/mtk/loader.py
@@ -274,6 +274,8 @@ class MTKLoader(firmwire.loader.Loader):
 
             while name in debug_info:
                 name = name + "_"
+            
+            name = name.strip("()")
             debug_info[name] = (start, end - start)
 
             if debug_data.tell() >= file_syms_off:

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -22,6 +22,7 @@ from firmwire.vendor.mtk.hooks import (
     msg_send_hook
 )
 from firmwire.vendor.mtk.mtk_task import MtkTask, TASK_STRUCT_SIZE
+from firmwire.vendor.mtk.mtkdb.memory_dump import MtkMemoryDump
 
 from firmwire.util.port import find_free_port
 from firmwire.emulator.firmwire import FirmWireEmu
@@ -814,3 +815,21 @@ class MT6878Machine(FirmWireEmu):
         )
 
         return task.address
+
+    def load_memory_dump(self):
+        self._mtk_memory_dump = MtkMemoryDump(self.get_memory_dump_file_path())
+
+
+    def restore_memory_dump(self):
+        log.info("Restoring memory dump")
+        count = 0
+        for (addr, size) in self.get_mem_dump_addrs():
+            buf = self._mtk_memory_dump.get(addr, size)
+            if buf is None:
+                continue
+
+            self.qemu.pypanda.physical_memory_write(addr, buf)
+            count += 1
+            if count % 500 == 0:
+                log.debug(f"Restored {count} chunks from memory dump...")
+        log.info(f"Memory dump recovery completed, restored {count} chunks")

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -413,15 +413,35 @@ class MT6878Machine(FirmWireEmu):
                 symbols["MML1_RF_Wait_us"] + 1,
                 # TODO: mutexes do not seem to be set up here
                 symbols["ccismc_submit_ior"] + 1,  # symbols['enqueue_gpd']+1
+                symbols["drv_idc_init"] + 1,
+                symbols["el1_idc_init"] + 1, # We need EL1 for LTE NAS, but EL1_IDC and EL1D partially fail to boot
+                symbols["el1c_init2"] + 1,
+                symbols["EL1D_TC_HW_Init"] + 1,
+                symbols["EL1D_TC_HW_Disable_All_IRQ"] + 1,
+                symbols["EL1D_RFCC_Init"] + 1,
+                symbols["EL1D_Main_Common_Init"] + 1,
+                symbols["emacdl_init"] + 1,
+                symbols["el1_chmgm_errc_cfg_req_in_idle"] + 1,
+                symbols["errc_com_start_timer"] + 1, # Disable a bunch of timers which do not work
+                symbols["errc_com_stop_timer"] + 1,
+                symbols["CEmmTimerMng::startTimer"] + 1,
+                symbols["CEmmTimerMng::stopTimer"] + 1,
+                symbols["sms_start_timer"] + 1,
+                symbols["sms_stop_timer"] + 1,
+                symbols["smsal_start_timer"] + 1,
+                symbols["smsal_stop_timer"] + 1 ,
+                symbols["ssipc_simslot_check"] + 1, # SMS
+                symbols["ss_log_msg_tag"] + 1, # SMS
+                symbols["epdcp_ulproc_dcch_data_req_hndlr"] + 1,
+                symbols["_ulproc_send_dcch_data_cnf"] + 1, # prevent problems due to missing RLC ACKs
             ]
         )
 
-        def skip_function_bp(x):
-            ra = qemu.read_register("ra")
-            qemu.write_register("pc", ra)
-
         for addr in skip_functions:
-            self.set_breakpoint(addr & ~1, skip_function_bp, continue_after=True)
+            # Performance optimization: Skip via writing a "ret" instruction to memory
+            # Rather than using a breakpoint
+            ret = b"\xa0\xe8\x00\x65" # JRC ra
+            self.panda.physical_memory_write(addr & ~1, ret)
 
         def exit_hook(self, env, tb, hook):
             print(
@@ -570,11 +590,13 @@ class MT6878Machine(FirmWireEmu):
             print("*** skipping assert")
             qemu.write_register("pc", symbols["errc_evth_inevt_handler_end"] + 1)
 
-        self.set_breakpoint(
-            symbols["errc_evth_inevt_handler_assert"],
-            skip_assert_bp,
-            continue_after=True,
-        )
+        # Un-comment the following block to skip asserts that occur when fuzzing without restoring a memory dump
+        # NOTE: This means you only fuzz early stage processing (e.g. ASN.1 parsing)
+        # self.set_breakpoint(
+        #     symbols["errc_evth_inevt_handler_assert"],
+        #     skip_assert_bp,
+        #     continue_after=True,
+        # )
 
         if not self._fuzzing:
             self.add_panda_hook(symbols["dhl_internal_trace_impl"], dhl_trace_hook)

--- a/firmwire/vendor/mtk/mtkdb/memory_dump.py
+++ b/firmwire/vendor/mtk/mtkdb/memory_dump.py
@@ -1,0 +1,127 @@
+## Copyright (c) 2025, Team FirmWire
+## SPDX-License-Identifier: BSD-3-Clause
+
+import struct
+import logging
+import os
+import snappy
+
+FILE_MAGIC = b"EDBGINFO"
+MUXZ_MAGIC = b"\x4d\x55\x5a\x1a"
+
+log = logging.getLogger(__name__)
+
+def is_muxz(file_path):
+    with open(file_path, "rb") as f:
+        magic = f.read(len(MUXZ_MAGIC))
+    return magic == MUXZ_MAGIC
+
+def uncompress_muxz(file_path):
+    with open(file_path, "rb") as f:
+        result_chunks = []
+        first_content_chunk = f.read(0x100)
+
+        header_start = first_content_chunk.find(MUXZ_MAGIC)+4
+        data_start = first_content_chunk.find(MUXZ_MAGIC, header_start)+4
+        if data_start <= 0:
+            print("Could not find start of MUXZ data")
+            return None
+        f.seek(data_start)
+
+        # 6 byte header
+        # 3 bytes: size of uncompressed contents
+        # 3 bytes: number of compressed bytes to uncompress
+        while True:
+            uncompressed_size_entry_chunk = f.read(3)
+            if len(uncompressed_size_entry_chunk) != 3:
+                break
+            uncompressed_chunk_size, = struct.unpack("<I", uncompressed_size_entry_chunk + b"\0")
+            chunk_size, = struct.unpack("<I", f.read(3) + b"\0")
+
+            try:
+                compressed = f.read(chunk_size)
+                assert(len(compressed) == chunk_size)
+                uncompressed_chunk = snappy.uncompress(compressed)
+
+                result_chunks.append(uncompressed_chunk)
+                data_start += chunk_size
+                assert(uncompressed_chunk_size == len(uncompressed_chunk))
+            except Exception as e:
+                print("Exception: {}".format(e))
+                break
+
+        joined = b''.join(result_chunks)
+        out_path = file_path + "_uncompressed"
+        with open(out_path, "wb") as out_f:
+            out_f.write(joined)
+        return out_path
+
+class MtkMemoryDump:
+    def __init__(self, path):
+        self.sections = []
+        if is_muxz(path):
+            log.info("Memory dump appears to be MUXZ compressed, uncompressing...")
+            uncompressed_path = uncompress_muxz(path)
+            if uncompressed_path is None:
+                raise ValueError("Failed to uncompress MUXZ memory dump")
+            path = uncompressed_path
+
+        with open(path, "rb") as f:
+            if not self.has_magic(f):
+                raise ValueError("Memory dump does not have expected magic bytes")
+
+            if not self.get_version(f) == 2:
+                raise ValueError("Unsupported memory dump version")
+
+            while f.tell() < os.path.getsize(path):
+                section = MtkMemoryDumpSection(f)
+                if not section.has_mapping():
+                    continue
+                self.sections.append(section)
+
+    def get(self, addr, length):
+        for section in self.sections:
+            if section.get_virtual_offset() <= addr and (section.get_virtual_offset() + section.length) >= (addr + length):
+                start = addr - section.get_virtual_offset()
+                end = start + length
+                return section.data[start:end]
+
+    def has_magic(self, f):
+        f.seek(0)
+        return f.read(len(FILE_MAGIC)) == FILE_MAGIC
+
+    def get_version(self, f):
+        f.seek(len(FILE_MAGIC))
+        version_bytes = f.read(4)
+        version = struct.unpack("<I", version_bytes)[0]
+        return version
+
+class MtkMemoryDumpSection:
+    def __init__(self, f):
+        self.header_offset = f.tell()
+        header_length, = struct.unpack("<I", f.read(0x4))
+        header_length = (header_length - 8) ^ 0xffffffff
+        inverse_section_name = f.read(header_length)
+        self.section_name = (''.join([chr(c ^ 0xff) for c in inverse_section_name[::-1]]))
+        self.length, = struct.unpack("<I", f.read(0x4))
+        self.data_offset = f.tell()
+        self.end_of_section = self.data_offset + self.length
+        self.data = f.read(self.length)
+        log.debug(f"Found section {self.section_name} with length {self.length}, starts at 0x{self.data_offset}, ends at 0x{self.end_of_section:X}")
+
+        if self.get_virtual_offset() is None:
+            log.debug(f"... ignoring section {self.section_name} during restoring")
+            return
+        log.debug(f"...mapping to 0x{self.get_virtual_offset():X}")
+
+    def get_virtual_offset(self):
+        if self.section_name.startswith("sys_mem_"):
+            return int(self.section_name[len("sys_mem_"):], 16)
+        else:
+            return None
+    
+    def has_mapping(self):
+        return self.get_virtual_offset() is not None
+
+    def get_data(self):
+        return self.data

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pyelftools
 requests
 # MTK required
 filetype
+python-snappy==0.7.3
 # Below required for pypanda
 cffi
 protobuf


### PR DESCRIPTION
This adds a feature to restore memory regions from a dump obtained from physical MTK CPs.
Dumps can be obtained either by crashing the modem, or via vendor specific debug menus.
To restore a dump:
- supply the file path to --mem-dump
- give a list of <addr>,<length> lines which specify which regions to restore to --mem-dump-addrs
- and supply an address of WHEN to restore memory to --load-mem-dump-at

Furthermore, this PR re-enables a bunch of tasks in favor of disabling the init-functions of some of their submodules, which allows far better coverage of the LTE NAS stack. This also means we disable the hook that skips the assertion in the RRC state machine (currently required when fuzzing with incomplete state). We might want to add a flag like `--skip-state-assertions` to selectively skip or not skip state related stuff. In this PR, the preliminary solution is to uncomment the block to re-enable the breakpoint.
To improve performance of skipping, I also included a performance improvement by @mariusmue which inserts return statements into skipped functions.

With all of these changes, the new recovery feature (and a mem dump and filter list that goes with it) FirmWire will reply to, e.g., a NAS identity request, and you can observe that with the `--gsmtap` feature introduced in #48. I will provide a more in-depth tutorial on this in the future, once we get BaseBridge itself open sourced.

Also fixes a couple of bugs here and there and slightly improves the MTK CIF peripheral.