### PR TITLE
Physical mem dump restoring, memory access tracing, bunch of MTK bugfixes

### DIFF
--- a/firmwire.py
+++ b/firmwire.py
@@ -77,6 +77,8 @@ def get_args():
         "--gsmtap", type=str, help="Stream packets from inside the baseband to this IP on port 4729 (gsmtap)"
     )
 
+    parser.add_argument_group
+
     fuzzopts = parser.add_argument_group("fuzzing options")
 
     fuzzopts.add_argument(
@@ -178,6 +180,28 @@ def get_args():
         help="Enable *full* coverage collection (logs every executed basic block)",
     )
 
+    # Memory dump options (must be all set or none)
+    mem_group = parser.add_argument_group("memory dump options", description=
+                                          "Options to load a memory dump into the emulated machine at a specific point. All three options must be provided to enable this feature.")
+    mem_group.add_argument(
+        "--mem-dump",
+        type=str,
+        default=None,
+        help="Path to memory dump file to load",
+    )
+    mem_group.add_argument(
+        "--load-mem-dump-at",
+        type=str,
+        default=None,
+        help="PC Address (hex) or symbol name when to load the memory dump",
+    )
+    mem_group.add_argument(
+        "--mem-dump-addrs",
+        type=str,
+        default=None,
+        help="Path to file listing addresses and lengths (one per line: <addr>,<len>)",
+    )
+
     ### Parse
     args = parser.parse_args()
 
@@ -191,6 +215,59 @@ def get_args():
 
     for name, validator in loader_specific_args.items():
         loader_specific_args[name] = validator.extract_relevant_params(args)
+
+    # Validate memory-dump options: either all provided or none
+    if args.mem_dump is not None or args.load_mem_dump_at is not None or args.mem_dump_addrs is not None:
+        if args.mem_dump is None or args.load_mem_dump_at is None or args.mem_dump_addrs is None:
+            parser.error(
+                "Options --mem-dump, --load-mem-dump-at and --mem-dump-addrs must be all set or none set"
+            )
+
+    # If provided, validate --mem-dump exists
+    if args.mem_dump is not None:
+        if not os.path.isfile(args.mem_dump):
+            parser.error(f"--mem-dump file does not exist: {args.mem_dump}")
+
+        # Parse the mem-dump-addrs file into a list of (addr, length) tuples
+        addrs_list = []
+        try:
+            with open(args.mem_dump_addrs, "r") as f:
+                for lineno, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = [p.strip() for p in line.split(",")]
+                    if len(parts) != 2:
+                        parser.error(
+                            f"Invalid line in --mem-dump-addrs at {args.mem_dump_addrs}:{lineno}: '{line}' (expected 'addr,length')"
+                        )
+                    try:
+                        addr = int(parts[0], 0)
+                        length = int(parts[1], 0)
+                    except Exception as e:
+                        parser.error(
+                            f"Invalid numeric value in --mem-dump-addrs at {args.mem_dump_addrs}:{lineno}: {e}"
+                        )
+                    if length <= 0:
+                        parser.error(
+                            f"Length must be positive in --mem-dump-addrs at {args.mem_dump_addrs}:{lineno}"
+                        )
+                    addrs_list.append((addr, length))
+        except FileNotFoundError:
+            parser.error(f"--mem-dump-addrs file does not exist: {args.mem_dump_addrs}")
+        except Exception as e:
+            parser.error(f"Failed to read --mem-dump-addrs: {e}")
+
+        args.mem_dump_addrs = addrs_list
+
+        # Parse --load-mem-dump-at: try numeric parse, otherwise leave as symbol string
+        s = args.load_mem_dump_at
+        try:
+            args.load_mem_dump_at = int(s, 0)
+        except Exception:
+            # keep as symbol name (string)
+            pass
+
 
     return args, loader_specific_args, params
 
@@ -295,6 +372,13 @@ def main() -> int:
 
     if args.gsmtap:
         machine.set_gsmtap_ip(args.gsmtap)
+
+    if args.mem_dump:
+        machine.configure_memory_dump(
+            dump_file=args.mem_dump,
+            load_at=args.load_mem_dump_at,
+            addrs=args.mem_dump_addrs,
+        )
 
     if loader.NAME == "shannon":
         # With shannon we can inject tasks overwriting the old one, even after snapshot restores for quick dev

--- a/firmwire.py
+++ b/firmwire.py
@@ -329,6 +329,13 @@ def main() -> int:
 
     log.info("Machine initialization time took %.2f seconds", machine.time_running())
 
+    if args.mem_dump:
+        machine.configure_memory_dump(
+            dump_file=args.mem_dump,
+            load_at=args.load_mem_dump_at,
+            addrs=args.mem_dump_addrs,
+        )
+
     if args.restore_snapshot:
         machine.restore_snapshot(args.restore_snapshot)
 
@@ -372,13 +379,6 @@ def main() -> int:
 
     if args.gsmtap:
         machine.set_gsmtap_ip(args.gsmtap)
-
-    if args.mem_dump:
-        machine.configure_memory_dump(
-            dump_file=args.mem_dump,
-            load_at=args.load_mem_dump_at,
-            addrs=args.mem_dump_addrs,
-        )
 
     if loader.NAME == "shannon":
         # With shannon we can inject tasks overwriting the old one, even after snapshot restores for quick dev

--- a/firmwire/emulator/firmwire.py
+++ b/firmwire/emulator/firmwire.py
@@ -49,6 +49,7 @@ class FirmWireEmu(ABC):
         self.start_time = None
         self._gsmtap_ip = None
         self._mem_dump_config = { "dump_file": None, "load_at": None, "load_after_snapshot": False, "addrs": None, "enabled": False }
+        self.memory_tracing_enabled = str(os.environ.get("ENABLE_MEMORY_TRACING", 0)) == '1'
 
     def set_breakpoint(self, address, handler, temporary=False, continue_after=False):
         """
@@ -752,6 +753,7 @@ class FirmWireEmu(ABC):
 
         self.load_memory_dump()
         self.set_breakpoint(self._mem_dump_config["load_at"], self.mem_dump_load_hook, continue_after=True, temporary=True)
+        self.memory_tracing_enabled = False # disable memory tracing when using memory dumps until dump is restored
 
     def is_memory_dump_enabled(self):
         """Check if memory dump loading is enabled"""

--- a/firmwire/emulator/firmwire.py
+++ b/firmwire/emulator/firmwire.py
@@ -736,6 +736,7 @@ class FirmWireEmu(ABC):
 
         if load_at == "SNAPSHOT_RESTORE":
             self._mem_dump_config["load_after_snapshot"] = True
+            self.load_memory_dump()
             return
             
         if isinstance(load_at, str):

--- a/firmwire/emulator/firmwire.py
+++ b/firmwire/emulator/firmwire.py
@@ -48,6 +48,7 @@ class FirmWireEmu(ABC):
         self.signal_count = 0
         self.start_time = None
         self._gsmtap_ip = None
+        self._mem_dump_config = { "dump_file": None, "load_at": None, "load_after_snapshot": False, "addrs": None, "enabled": False }
 
     def set_breakpoint(self, address, handler, temporary=False, continue_after=False):
         """
@@ -287,6 +288,9 @@ class FirmWireEmu(ABC):
             self.remove_breakpoint(bid)
 
         assert len(self._bp_map) == 0
+        
+        if self.is_memory_dump_to_be_restored_on_snapshot():
+            self.restore_memory_dump()
 
         breakpoints = machine_state["breakpoints"]
 
@@ -722,3 +726,59 @@ class FirmWireEmu(ABC):
 
     def get_gsmtap_ip(self):
         return self._gsmtap_ip
+    
+    def configure_memory_dump(self, dump_file, load_at, addrs):
+        """Configure memory dump loading options"""
+        self._mem_dump_config["dump_file"] = dump_file
+        self._mem_dump_config["addrs"] = addrs
+        self._mem_dump_config["enabled"] = True
+
+        if load_at == "SNAPSHOT_RESTORE":
+            self._mem_dump_config["load_after_snapshot"] = True
+            return
+            
+        if isinstance(load_at, str):
+            #sym = self.symbol_table.lookup(load_at)
+            sym = self.symbols.get(load_at, None)
+            if sym is None:
+                log.error(
+                    f"Unable to find symbol {load_at} for memory dump restore"
+                )
+                raise RuntimeError("Memory dump configuration failure")
+            else:
+                self._mem_dump_config["load_at"] = sym
+        else:
+            self._mem_dump_config["load_at"] = load_at
+
+        self.load_memory_dump()
+        self.set_breakpoint(self._mem_dump_config["load_at"], self.mem_dump_load_hook, continue_after=True, temporary=True)
+
+    def is_memory_dump_enabled(self):
+        """Check if memory dump loading is enabled"""
+        return self._mem_dump_config["enabled"]
+
+    def is_memory_dump_to_be_restored_on_snapshot(self):
+        """Check if memory dump loading is configured to occur after snapshot restore"""
+        return self._mem_dump_config["load_after_snapshot"]
+
+    def get_memory_dump_file_path(self):
+        """Get the memory dump file path"""
+        return self._mem_dump_config["dump_file"]
+
+    def get_mem_dump_addrs(self):
+        """Get the memory dump addresses configuration"""
+        return self._mem_dump_config["addrs"]
+
+    def mem_dump_load_hook(self):
+        if not self._mem_dump_config["enabled"]:
+            log.debug("Memory dump loading not enabled, skipping hook")
+            return
+        self.restore_memory_dump()
+
+    def load_memory_dump(self):
+        """Overrideable function to load a memory dump for later restoring. Called during configuration."""
+        pass
+
+    def restore_memory_dump(self):
+        """Overrideable function to restore a memory dump. Called once the recovery breakpoint is hit or during snapshot restore, if requested."""
+        raise Exception("Memory dump loading not implemented for current machine")

--- a/firmwire/emulator/guestlogs.py
+++ b/firmwire/emulator/guestlogs.py
@@ -111,9 +111,6 @@ class FirmWireGuestLogger:
 
             for vibe_check in self._banned_log_patterns:
                 if vibe_check.search(this_msg):
-                    if address is not None:
-                        self._banned_addresses.add(address)
-
                     if log_hash is not None:
                         self._banned_log_hashes.add(log_hash)
 

--- a/firmwire/vendor/mtk/consts.py
+++ b/firmwire/vendor/mtk/consts.py
@@ -141,12 +141,7 @@ TASKNAMES_DEACTIVATED = [
     # 2G/3G
     "MRF",
     # LTE
-    "ERT",
     "EMACDL",
-    "EL2H",
-    "EL2",
-    "EL1",
-    "EL1_MPC",
     "MLL1",
     # Middle ware
     "AUDIO",

--- a/firmwire/vendor/mtk/hooks.py
+++ b/firmwire/vendor/mtk/hooks.py
@@ -217,10 +217,11 @@ def msg_send_hook(self, env, tb, param3):
         task_name=self._current_task_name,
         address=ra,
     )
-    if msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ"]:
-        gsmtap_uplink_errc_dcch_data(self, env, struct_addr)
-    elif msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_IND"]:
-        gsmtap_downlink_errc_dcch_data(self, env, struct_addr)
+    if self.get_gsmtap_ip() is not None:
+        if msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_REQ"]:
+            gsmtap_uplink_errc_dcch_data(self, env, struct_addr)
+        elif msg_id == self.loader.msg_ids["MSG_ID_ERRC_EPDCP_DCCH_DATA_IND"]:
+            gsmtap_downlink_errc_dcch_data(self, env, struct_addr)
 
 
 def gsmtap_uplink_errc_dcch_data(self, cpu, msg_struct_addr):

--- a/firmwire/vendor/mtk/hw/PCCIFPeripheral.py
+++ b/firmwire/vendor/mtk/hw/PCCIFPeripheral.py
@@ -481,11 +481,21 @@ class PCCIF_Periph(PassthroughPeripheral):
                 assert value == 0
                 self.handleAMMS()
                 return True
-            if value == 15:  # TODO: should prbly be >=15
+            if value == 15:
                 # RINGQ_SRAM
                 self.handle_SRAM_write()
-            else:
-                if value >= len(self.ringbuffer.offsets):
+            else: # drivers/misc/mediatek/eccci/mt6768/ccif_hif_platform.h
+                if value >= 16 and value <= 19:
+                    self.log.error(
+                        f"CCCI Received D2H exception ({value})"
+                    )
+                    assert False
+                elif value == 21:
+                    self.log.error(
+                        f"CCCI Received AP MD SEQ error"
+                    )
+                    assert False
+                elif value >= len(self.ringbuffer.offsets):
                     self.log.error(
                         f"PCCIF ring no too large (value: {value}, is only: {len(self.ringbuffer.offsets)})"
                     )

--- a/firmwire/vendor/mtk/loader.py
+++ b/firmwire/vendor/mtk/loader.py
@@ -274,6 +274,8 @@ class MTKLoader(firmwire.loader.Loader):
 
             while name in debug_info:
                 name = name + "_"
+            
+            name = name.strip("()")
             debug_info[name] = (start, end - start)
 
             if debug_data.tell() >= file_syms_off:

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -641,7 +641,8 @@ class MT6878Machine(FirmWireEmu):
                     return
 
                 ra = self.qemu.pypanda.arch.get_reg(env, "RA")
-                obj = {"addr": addr, "length": size, "pc": pc, "ra": ra, "fn": get_containing_fn(pc), "fn_ra": get_containing_fn(ra)}
+                sp = self.qemu.pypanda.arch.get_reg(env, "SP")
+                obj = {"addr": addr, "length": size, "pc": pc, "ra": ra, "sp": sp, "fn": get_containing_fn(pc), "fn_ra": get_containing_fn(ra)}
                 self.function_memory_access['w'].append(obj)
                 sys.stdout.write(f"\nMEM_WRITE: {json.dumps(obj)}\n")
                 sys.stdout.flush()
@@ -652,7 +653,8 @@ class MT6878Machine(FirmWireEmu):
                     return
 
                 ra = self.qemu.pypanda.arch.get_reg(env, "RA")
-                obj = {"addr": addr, "length": size, "pc": pc, "ra": ra, "fn": get_containing_fn(pc), "fn_ra": get_containing_fn(ra)}
+                sp = self.qemu.pypanda.arch.get_reg(env, "SP")
+                obj = {"addr": addr, "length": size, "pc": pc, "ra": ra, "sp": sp, "fn": get_containing_fn(pc), "fn_ra": get_containing_fn(ra)}
                 self.function_memory_access['r'].append(obj)
                 sys.stdout.write(f"\nMEM_READ: {json.dumps(obj)}\n")
                 sys.stdout.flush()

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -771,6 +771,7 @@ class MT6878Machine(FirmWireEmu):
         # This is some whacky stuff to make restores work. I
         # I suspect that our MTK machine introduced a bug into panda and some global state isn't being captured
 
+        self.qemu.pypanda.disable_memcb()
         log.warning("MTK snapshot quirk: First restore...")
         super().restore_snapshot(snapshot_name)
 
@@ -783,6 +784,7 @@ class MT6878Machine(FirmWireEmu):
 
         log.warning("MTK snapshot quirk: Stopping target...")
         self.qemu.stop(blocking=True)
+        self.qemu.pypanda.enable_memcb()
 
         log.warning("MTK snapshot quirk: Second restore...")
         super().restore_snapshot(snapshot_name)

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -22,6 +22,7 @@ from firmwire.vendor.mtk.hooks import (
     msg_send_hook
 )
 from firmwire.vendor.mtk.mtk_task import MtkTask, TASK_STRUCT_SIZE
+from firmwire.vendor.mtk.mtkdb.memory_dump import MtkMemoryDump
 
 from firmwire.util.port import find_free_port
 from firmwire.emulator.firmwire import FirmWireEmu
@@ -814,3 +815,21 @@ class MT6878Machine(FirmWireEmu):
         )
 
         return task.address
+
+    def load_memory_dump(self):
+        self._mtk_memory_dump = MtkMemoryDump(self.get_memory_dump_file_path())
+
+
+    def restore_memory_dump(self):
+        log.info("Restoring memory dump")
+        count = 0
+        for (addr, size) in self.get_mem_dump_addrs():
+            buf = self._mtk_memory_dump.get(addr, size)
+            if buf is None:
+                continue
+
+            self.qemu.pypanda.physical_memory_write(addr, buf)
+            count += 1
+            if count % 500 == 0:
+                log.debug(f"Restored {count} chunks from memory dump...")
+        log.info(f"Memory dump recovery completed, restored {count} chunks")

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -627,6 +627,37 @@ class MT6878Machine(FirmWireEmu):
 
         fcntl.fcntl(sys.stdout.fileno(), fcntl.F_SETFL, 0)  # remove non-block
 
+        if str(os.environ.get("ENABLE_MEMORY_TRACING", 0)) == '1':
+            sorted_function_starts = sorted(self.symbols.values(), reverse=True)
+            self.function_memory_access = {'r': [], 'w': []}
+
+            def get_containing_fn(addr):
+                return next((curr_fn_addr for curr_fn_addr in sorted_function_starts if curr_fn_addr <= addr), list(sorted_function_starts)[0])
+
+
+            @qemu.pypanda.cb_phys_mem_before_write
+            def mem_before_write(env, pc, addr, size, buf):
+                if not self.memory_tracing_enabled:
+                    return
+
+                ra = self.qemu.pypanda.arch.get_reg(env, "RA")
+                obj = {"addr": addr, "length": size, "pc": pc, "ra": ra, "fn": get_containing_fn(pc), "fn_ra": get_containing_fn(ra)}
+                self.function_memory_access['w'].append(obj)
+                sys.stdout.write(f"\nMEM_WRITE: {json.dumps(obj)}\n")
+                sys.stdout.flush()
+
+            @qemu.pypanda.cb_phys_mem_before_read
+            def mem_before_read_hook(env, pc, addr, size):
+                if not self.memory_tracing_enabled:
+                    return
+
+                ra = self.qemu.pypanda.arch.get_reg(env, "RA")
+                obj = {"addr": addr, "length": size, "pc": pc, "ra": ra, "fn": get_containing_fn(pc), "fn_ra": get_containing_fn(ra)}
+                self.function_memory_access['r'].append(obj)
+                sys.stdout.write(f"\nMEM_READ: {json.dumps(obj)}\n")
+                sys.stdout.flush()
+
+
         # @qemu.pypanda.ppp("callstack_instr", "on_call")
         # def on_call(cpu, func):
         #    print(f"Call to 0x{func:x}")
@@ -855,3 +886,5 @@ class MT6878Machine(FirmWireEmu):
             if count % 500 == 0:
                 log.debug(f"Restored {count} chunks from memory dump...")
         log.info(f"Memory dump recovery completed, restored {count} chunks")
+        self.memory_tracing_enabled = str(os.environ.get("ENABLE_MEMORY_TRACING", 0)) == '1'
+

--- a/firmwire/vendor/mtk/machine.py
+++ b/firmwire/vendor/mtk/machine.py
@@ -413,15 +413,35 @@ class MT6878Machine(FirmWireEmu):
                 symbols["MML1_RF_Wait_us"] + 1,
                 # TODO: mutexes do not seem to be set up here
                 symbols["ccismc_submit_ior"] + 1,  # symbols['enqueue_gpd']+1
+                symbols["drv_idc_init"] + 1,
+                symbols["el1_idc_init"] + 1, # We need EL1 for LTE NAS, but EL1_IDC and EL1D partially fail to boot
+                symbols["el1c_init2"] + 1,
+                symbols["EL1D_TC_HW_Init"] + 1,
+                symbols["EL1D_TC_HW_Disable_All_IRQ"] + 1,
+                symbols["EL1D_RFCC_Init"] + 1,
+                symbols["EL1D_Main_Common_Init"] + 1,
+                symbols["emacdl_init"] + 1,
+                symbols["el1_chmgm_errc_cfg_req_in_idle"] + 1,
+                symbols["errc_com_start_timer"] + 1, # Disable a bunch of timers which do not work
+                symbols["errc_com_stop_timer"] + 1,
+                symbols["CEmmTimerMng::startTimer"] + 1,
+                symbols["CEmmTimerMng::stopTimer"] + 1,
+                symbols["sms_start_timer"] + 1,
+                symbols["sms_stop_timer"] + 1,
+                symbols["smsal_start_timer"] + 1,
+                symbols["smsal_stop_timer"] + 1 ,
+                symbols["ssipc_simslot_check"] + 1, # SMS
+                symbols["ss_log_msg_tag"] + 1, # SMS
+                symbols["epdcp_ulproc_dcch_data_req_hndlr"] + 1,
+                symbols["_ulproc_send_dcch_data_cnf"] + 1, # prevent problems due to missing RLC ACKs
             ]
         )
 
-        def skip_function_bp(x):
-            ra = qemu.read_register("ra")
-            qemu.write_register("pc", ra)
-
         for addr in skip_functions:
-            self.set_breakpoint(addr & ~1, skip_function_bp, continue_after=True)
+            # Performance optimization: Skip via writing a "ret" instruction to memory
+            # Rather than using a breakpoint
+            ret = b"\xa0\xe8\x00\x65" # JRC ra
+            self.panda.physical_memory_write(addr & ~1, ret)
 
         def exit_hook(self, env, tb, hook):
             print(
@@ -570,11 +590,13 @@ class MT6878Machine(FirmWireEmu):
             print("*** skipping assert")
             qemu.write_register("pc", symbols["errc_evth_inevt_handler_end"] + 1)
 
-        self.set_breakpoint(
-            symbols["errc_evth_inevt_handler_assert"],
-            skip_assert_bp,
-            continue_after=True,
-        )
+        # Un-comment the following block to skip asserts that occur when fuzzing without restoring a memory dump
+        # NOTE: This means you only fuzz early stage processing (e.g. ASN.1 parsing)
+        # self.set_breakpoint(
+        #     symbols["errc_evth_inevt_handler_assert"],
+        #     skip_assert_bp,
+        #     continue_after=True,
+        # )
 
         if not self._fuzzing:
             self.add_panda_hook(symbols["dhl_internal_trace_impl"], dhl_trace_hook)

--- a/firmwire/vendor/mtk/mtkdb/memory_dump.py
+++ b/firmwire/vendor/mtk/mtkdb/memory_dump.py
@@ -1,0 +1,127 @@
+## Copyright (c) 2025, Team FirmWire
+## SPDX-License-Identifier: BSD-3-Clause
+
+import struct
+import logging
+import os
+import snappy
+
+FILE_MAGIC = b"EDBGINFO"
+MUXZ_MAGIC = b"\x4d\x55\x5a\x1a"
+
+log = logging.getLogger(__name__)
+
+def is_muxz(file_path):
+    with open(file_path, "rb") as f:
+        magic = f.read(len(MUXZ_MAGIC))
+    return magic == MUXZ_MAGIC
+
+def uncompress_muxz(file_path):
+    with open(file_path, "rb") as f:
+        result_chunks = []
+        first_content_chunk = f.read(0x100)
+
+        header_start = first_content_chunk.find(MUXZ_MAGIC)+4
+        data_start = first_content_chunk.find(MUXZ_MAGIC, header_start)+4
+        if data_start <= 0:
+            print("Could not find start of MUXZ data")
+            return None
+        f.seek(data_start)
+
+        # 6 byte header
+        # 3 bytes: size of uncompressed contents
+        # 3 bytes: number of compressed bytes to uncompress
+        while True:
+            uncompressed_size_entry_chunk = f.read(3)
+            if len(uncompressed_size_entry_chunk) != 3:
+                break
+            uncompressed_chunk_size, = struct.unpack("<I", uncompressed_size_entry_chunk + b"\0")
+            chunk_size, = struct.unpack("<I", f.read(3) + b"\0")
+
+            try:
+                compressed = f.read(chunk_size)
+                assert(len(compressed) == chunk_size)
+                uncompressed_chunk = snappy.uncompress(compressed)
+
+                result_chunks.append(uncompressed_chunk)
+                data_start += chunk_size
+                assert(uncompressed_chunk_size == len(uncompressed_chunk))
+            except Exception as e:
+                print("Exception: {}".format(e))
+                break
+
+        joined = b''.join(result_chunks)
+        out_path = file_path + "_uncompressed"
+        with open(out_path, "wb") as out_f:
+            out_f.write(joined)
+        return out_path
+
+class MtkMemoryDump:
+    def __init__(self, path):
+        self.sections = []
+        if is_muxz(path):
+            log.info("Memory dump appears to be MUXZ compressed, uncompressing...")
+            uncompressed_path = uncompress_muxz(path)
+            if uncompressed_path is None:
+                raise ValueError("Failed to uncompress MUXZ memory dump")
+            path = uncompressed_path
+
+        with open(path, "rb") as f:
+            if not self.has_magic(f):
+                raise ValueError("Memory dump does not have expected magic bytes")
+
+            if not self.get_version(f) == 2:
+                raise ValueError("Unsupported memory dump version")
+
+            while f.tell() < os.path.getsize(path):
+                section = MtkMemoryDumpSection(f)
+                if not section.has_mapping():
+                    continue
+                self.sections.append(section)
+
+    def get(self, addr, length):
+        for section in self.sections:
+            if section.get_virtual_offset() <= addr and (section.get_virtual_offset() + section.length) >= (addr + length):
+                start = addr - section.get_virtual_offset()
+                end = start + length
+                return section.data[start:end]
+
+    def has_magic(self, f):
+        f.seek(0)
+        return f.read(len(FILE_MAGIC)) == FILE_MAGIC
+
+    def get_version(self, f):
+        f.seek(len(FILE_MAGIC))
+        version_bytes = f.read(4)
+        version = struct.unpack("<I", version_bytes)[0]
+        return version
+
+class MtkMemoryDumpSection:
+    def __init__(self, f):
+        self.header_offset = f.tell()
+        header_length, = struct.unpack("<I", f.read(0x4))
+        header_length = (header_length - 8) ^ 0xffffffff
+        inverse_section_name = f.read(header_length)
+        self.section_name = (''.join([chr(c ^ 0xff) for c in inverse_section_name[::-1]]))
+        self.length, = struct.unpack("<I", f.read(0x4))
+        self.data_offset = f.tell()
+        self.end_of_section = self.data_offset + self.length
+        self.data = f.read(self.length)
+        log.debug(f"Found section {self.section_name} with length {self.length}, starts at 0x{self.data_offset}, ends at 0x{self.end_of_section:X}")
+
+        if self.get_virtual_offset() is None:
+            log.debug(f"... ignoring section {self.section_name} during restoring")
+            return
+        log.debug(f"...mapping to 0x{self.get_virtual_offset():X}")
+
+    def get_virtual_offset(self):
+        if self.section_name.startswith("sys_mem_"):
+            return int(self.section_name[len("sys_mem_"):], 16)
+        else:
+            return None
+    
+    def has_mapping(self):
+        return self.get_virtual_offset() is not None
+
+    def get_data(self):
+        return self.data

--- a/modkit/mtk/Makefile
+++ b/modkit/mtk/Makefile
@@ -57,12 +57,13 @@ COMMON_DEP := $(addprefix $(BUILD_DIR)/, $(COMMON_SRC:.c=.d))
 
 #######################################
 
-MODS := hello_world msg_inject_test lte_rrc
+MODS := hello_world msg_inject_test lte_rrc lte_rrc_sequence
 
 hello_world_SRC := hello_world.c
 
 msg_inject_test_SRC := msg_inject_test.c
 lte_rrc_SRC := fuzzers/lte_rrc.c afl.c
+lte_rrc_sequence_SRC := fuzzers/lte_rrc_sequence.c afl.c
 
 #######################################
 

--- a/modkit/mtk/fuzzers/lte_rrc_sequence.c
+++ b/modkit/mtk/fuzzers/lte_rrc_sequence.c
@@ -1,0 +1,256 @@
+#include <task.h>
+#include <modkit.h>
+#include <afl.h>
+#include "common.h"
+#include "mtk_api.h"
+#include "ota_data.h"
+
+#define DEBUG_PRINTS
+#define PARA_STRUCT_SIZE 0xc
+#define PARA_STRUCT_PLSIZE (PARA_STRUCT_SIZE-4)
+
+#define TASK_ID_IDLE 0x3a7
+#define TASK_ID_ERRC 0x298
+#define MSG_ID_MCCH 0x57eb
+#define MSG_ID_DCCH 0x57f8
+#define MSG_ID_CCCH 0x57e3
+#define MSG_ID_BCCH 0x57b3
+
+MODKIT_FUNCTION_SYMBOL(char *, prbm_allocate, int, int)
+MODKIT_FUNCTION_SYMBOL(char *, prbm_release, int, int, int)
+MODKIT_FUNCTION_SYMBOL(char *, errc_lcom_get_emi_address, int, int)
+MODKIT_FUNCTION_SYMBOL(void *, get_int_ctrl_buffer, int, char *, int)
+
+MODKIT_FUNCTION_SYMBOL(void, errc_set_current_errc_sim_idx_cntx_ptr, int)
+
+MODKIT_FUNCTION_SYMBOL(void, dhl_report_version2)
+
+// first gets the id?
+// second gets some 0/1 value
+// third is some kind of idx
+//MODKIT_FUNCTION_SYMBOL(char *, errc_lcom_get_free_buffer, char *, char *, char)
+
+// agh we need more fields set :( so we go with this Horrible Thing
+// first gets id
+// second is the TYPE, we need it to be 0x1, maybe SI type?
+// third gets ORed with (id & 0x1f)
+// fourth is ???
+// fifth is stored somewhere, sometimes +3
+// sixth is stored somewhere, sometimes added to fifth, can't be too low, idk
+// seventh is stored somewhere
+// eighth is the idx passed to errc_lcom_get_free_buffer
+// ninth is stored somewhere
+MODKIT_FUNCTION_SYMBOL(char *, errc_get_lte_buffer, char *, char, unsigned short *, unsigned int, unsigned int, unsigned int, unsigned int, char, unsigned int)
+
+MODKIT_FUNCTION_SYMBOL(void, errc_spv_write_errc_state, char);
+
+const char TASK_NAME[] = "AFL_LTE_RRC\0";
+
+MODKIT_DATA_SYMBOL(char *, epdcp_errc_mcch_data_buffer_free)
+MODKIT_DATA_SYMBOL(char *, epdcp_errc_dcch_data_buffer_free)
+MODKIT_DATA_SYMBOL(char *, emac_errc_ccch_data_buffer_free)
+MODKIT_DATA_SYMBOL(char *, errc_asn1_mem_free)
+	
+char *asn_pl;
+
+int fuzz_single_setup()
+{
+    const char jrcnop[4] = "\xa0\xe8\x00\x65";
+
+    // output version for debugging
+    dhl_report_version2();
+
+    // reallocating buffers outside startWork is bad
+    // because it doesn't trigger aborts
+    // and in persistent mode, OS state can be messed up
+    // -> we just allocate a large buffer here
+    //asn_pl = prbm_allocate(0x200, 1);
+    
+
+#if 0
+    // first param is sim idx, second is emi id
+    // note: first ERRC dest msg id is sim 0, second is sim 1, third is sim 0, etc
+    char *emi_buffer = errc_lcom_get_emi_address(0, 0);
+    dhl_print_string(2, 0, 0, "[+] emi addr %x\n", emi_buffer);
+    unsigned int length = 0x20; // 0x3ff max
+    // must pass checks in errc_lsys_chk_hw_ctrl_info
+    *(unsigned int *)(emi_buffer + 0x0) = 2 | (length << 20);
+    *(unsigned int *)(emi_buffer + 0x4) = 0 /* 0x3ff max */ | (0 << 10) /* 3f max */;
+#endif
+
+    // stop some functions from calling copro_vrb_release
+    // since we didn't allocate the buffer using dpcopro
+    memcpy(epdcp_errc_mcch_data_buffer_free, jrcnop, 4);
+    memcpy(epdcp_errc_dcch_data_buffer_free, jrcnop, 4);
+    memcpy(emac_errc_ccch_data_buffer_free, jrcnop, 4);
+
+    // disable the AsnFreeDecodedWithBlock call in errc_asn1_mem_free
+    // we don't care about the double-free on the error path (for MCCH)
+    memcpy(errc_asn1_mem_free, jrcnop, 4);
+
+    // 3 is likely ERRC_CONNECTED or LTE_RRC_STATE_CONNECTED?
+#ifdef ASSUME_CONNECTED_STATE
+    #ifdef DEBUG_PRINTS
+        dhl_print_string(2, 0, 0, "[+] Patching state");
+    #endif
+    errc_set_current_errc_sim_idx_cntx_ptr(0);
+    errc_spv_write_errc_state(3);
+    errc_set_current_errc_sim_idx_cntx_ptr(1);
+    errc_spv_write_errc_state(3);
+#endif
+
+    return 1;
+}
+
+void fuzz_single()
+{
+    uint32_t input_size;
+    uint16_t size;
+    local_para_struct *_local_para_ptr;
+    peer_buff_struct *_peer_buff_ptr = (void *)0;
+
+#ifdef DEBUG_PRINTS
+    dhl_print_string(2, 0, 0, "[+] Getting Work\n");
+#endif
+    char * buf = getWork(&input_size);
+    size = (uint16_t) input_size;
+
+#ifdef DEBUG_PRINTS
+    dhl_print_string(2, 0, 0, "[+] Work buf at %x\n", buf);
+#endif
+
+#ifdef DEBUG_PRINTS
+    dhl_print_string(2, 0, 0, "[+] Received %d bytes\n", size);
+#endif
+
+    if (size < 4) // must be at least one byte apparently, and need the type/pdu also
+    {
+        startWork(0, 0xffffffff); // memory range to collect coverage
+        dhl_print_string(2, 0, 0, "[+] Too small, fail\n");
+        doneWork(0);
+        return;
+    }
+    unsigned int my_num;
+
+#ifdef DEBUG_PRINTS
+    dhl_print_string(2, 0, 0, "[+] calling alloc_local_para\n");
+#endif
+
+    size_t offset = 0;
+    startWork(0, 0xffffffff); // memory range to collect coverage
+    asn_pl = get_int_ctrl_buffer(0x200, "", 1);
+    memset(asn_pl, 0, 0x200);
+
+    while (offset + 3 < size) {
+        DlControlChannelsLte_t input_type = buf[offset++] % DlControlChannelsLteCount;
+        #ifdef DEBUG_PRINTS
+            dhl_print_string(2, 0, 0, "[+] type is %d\n", input_type);
+        #endif
+        input_size = (uint16_t)buf[offset++] | ((uint16_t)buf[offset++] << 8);
+        #ifdef DEBUG_PRINTS
+            dhl_print_string(2, 0, 0, "[+] size is %d\n", input_size);
+        #endif
+        if (input_size < 0x1)
+        {
+            break;
+        }        
+        if (input_size > 0x115) // max RRC packet size (might even be smaller, but this seems ok)
+        {
+            break;
+        }
+        if (input_size > (size - offset)) {
+            break;
+        }
+
+        switch (input_type) {
+            case MCCH: // MCCH
+                _local_para_ptr = alloc_local_para(0x8 + 0x8);
+                memcpy(((char *)_local_para_ptr) + 0x8, &asn_pl, 4);
+                memcpy(((char *)_local_para_ptr) + 0xc, &input_size, 4);
+                break;
+            case DCCH: // DL_DCCH
+                #ifdef DEBUG_PRINTS
+                    dhl_print_string(2, 0, 0, "[+] Composing DCCH message\n", input_size);
+                #endif
+                _local_para_ptr = alloc_local_para(0x8 + 0x10);
+                memcpy(((char *)_local_para_ptr) + 0x10, &asn_pl, 4);
+                my_num = input_size + 4; // last 4 bytes are something else, there's a memcmp /after/ asn1 parsing
+                memcpy(((char *)_local_para_ptr) + 0x14, &my_num, 4);
+                my_num = 2; // 2 seems to be active state?
+                memcpy(((char *)_local_para_ptr) + 0x8, &my_num, 4);
+                break;
+            case CCCH: // DL_CCCH
+                _local_para_ptr = alloc_local_para(0x8 + 0x4);
+                memcpy(((char *)_local_para_ptr) + 0x4, &asn_pl, 4); // FIXME: this can't be right...???
+                memcpy(((char *)_local_para_ptr) + 0x8, &input_size, 4);
+                break;
+            case BCCH_DL_SCH: // BCCH_DL_SCH
+                _local_para_ptr = alloc_local_para(0x8 + 0x10);
+
+                // get through checks in errc_lsys_main
+                *((char *)_local_para_ptr + 0xd) = 0x0;
+                *((char *)_local_para_ptr + 0xe) = 0x0;
+
+                {
+                char bufid = 0x0;
+                unsigned short unk1 = 0x0;
+                char *lte_buf = errc_get_lte_buffer(&bufid, 1, &unk1, 0, 0, 0, 0, 0, 0);
+                *(unsigned int *)(lte_buf + 0x0) = 2 | (input_size << 20);
+                *(unsigned int *)(lte_buf + 0x4) = 0 /* 0x3ff max */ | (0 << 10) /* 3f max */;
+                asn_pl = (char *)(lte_buf + 0x8);
+        #ifdef DEBUG_PRINTS
+                dhl_print_string(2, 0, 0, "[+] bufid %x, unk1 %x, ptr %x\n", bufid, unk1, lte_buf);
+        #endif
+                *(unsigned short *)((char *)_local_para_ptr + 0x10) = unk1; // AND with 0x1f for buffer id
+                }
+                break;
+            default:
+                dhl_print_string(2, 0, 0, "[+] Invalid ASN1 id %x\n", buf[0]);
+                startWork(0, 0xffffffff); // memory range to collect coverage
+                doneWork(0);
+                return;
+        }
+        //dhl_print_string(2, 0, 0, "[+] filling in para_ptr\n");
+
+    #ifdef DEBUG_PRINTS
+        dhl_print_string(2, 0, 0, "[+] copying asn payload\n");
+    #endif
+        memcpy(asn_pl, buf+offset, input_size);
+
+    #ifdef DEBUG_PRINTS
+        dhl_print_string(2, 0, 0, "[+] FIRE\n");
+    #endif
+
+        switch (input_type) {
+            case MCCH:
+        //#define MCCH_FOR_A10s
+        #ifdef MCCH_FOR_A10s
+                // early builds:
+                //msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, 0x57e0, _local_para_ptr, _peer_buff_ptr);
+                // as of U5BTCB:
+                msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, 0x57e6, _local_para_ptr, _peer_buff_ptr);
+
+        #else
+                msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, MSG_ID_MCCH, _local_para_ptr, _peer_buff_ptr);
+        #endif
+                break;
+            case DCCH:
+                msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, MSG_ID_DCCH, _local_para_ptr, _peer_buff_ptr);
+                break;
+            case CCCH:
+                msg_send6(TASK_ID_IDLE, TASK_ID_ERRC, 0, MSG_ID_CCCH, _local_para_ptr, _peer_buff_ptr);
+                break;
+            case BCCH_DL_SCH:
+                // setting the source module to 0x4b avoids double-free in destroy_int_ilm, let's not ask too many questions
+                msg_send6(0x4b, TASK_ID_ERRC, 0, MSG_ID_BCCH, _local_para_ptr, _peer_buff_ptr);
+                break;
+        }
+        offset += input_size;
+    }
+    doneWork(0);
+
+#if 0
+    if (prbm_alloc_size)
+        prbm_release(asn_pl, prbm_alloc_size, 1);
+#endif
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pyelftools
 requests
 # MTK required
 filetype
+python-snappy==0.7.3
 # Below required for pypanda
 cffi
 protobuf


### PR DESCRIPTION
This adds a feature to restore memory regions from a dump obtained from physical MTK CPs.
Dumps can be obtained either by crashing the modem, or via vendor specific debug menus.
To restore a dump:

- supply the file path to `--mem-dump`
- give a list of , lines which specify which regions to restore to `--mem-dump-addrs`
- and supply an address of WHEN to restore memory to `--load-mem-dump-at`

Furthermore, this PR re-enables a bunch of tasks in favor of disabling the init-functions of some of their submodules, which allows far better coverage of the LTE NAS stack. This also means we disable the hook that skips the assertion in the RRC state machine (currently required when fuzzing with incomplete state). We might want to add a flag like --skip-state-assertions to selectively skip or not skip state related stuff. In this PR, the preliminary solution is to uncomment the block to re-enable the breakpoint.
To improve performance of skipping, I also included a performance improvement by @mariusmue which inserts return statements into skipped functions.

With all of these changes, the new recovery feature (and a mem dump and filter list that goes with it) FirmWire will reply to, e.g., a NAS identity request, and you can observe that with the --gsmtap feature introduced in https://github.com/FirmWire/FirmWire/pull/48. I will provide a more in-depth tutorial on this in the future, once we get BaseBridge itself open sourced.

To enable external applications, such as BaseBridge, to observe execution, this PR also adds an environment variable called `ENABLE_MEMORY_TRACING`. If you set `ENABLE_MEMORY_TRACING=1`, stdout will contain entries of the format `MEM_READ: {"addr": xxx, "length": xxx, "pc": xxx, "ra": xxx, "sp":xxx, "fn": xxx, "fn_ra": xxx}` (same for MEM_WRITE) for every memory access made. addr is the address that is being read/written, length is the number of bytes read/written, pc, ra and sp are register values, and fn as well as fn_ra are the addresses of the functions that pc and ra point to. Note that the `ra` is read from the register directly, and does not consider RA's stored to the stack. This feature is currently MTK only, and slows down execution significantly.

Lastly, this PR also contains a new AFL-compatible modkit for MTK that allows you to inject multiple packets. It works like the usual lte_rrc modkit, except that it will loop over the input, read a length `n` from the input, consider the next `n` bytes to be the packet, and then read the next length.

Also fixes a couple of bugs here and there and slightly improves the MTK CIF peripheral.