### PR TITLE
Shannon support for gsmtap features

### DIFF
--- a/firmwire/vendor/shannon/hooks.py
+++ b/firmwire/vendor/shannon/hooks.py
@@ -12,6 +12,14 @@ from .queue import QUEUE_STRUCT_SIZE, QUEUE_NAME_PTR_OFFSET
 
 from firmwire.util.panda import read_cstring_panda
 
+from firmwire.util.gsmtap import (
+    gsmtap_type,
+    gsmtap_lte_rrc_types,
+    send_gsmtap_packet,
+    create_gsmtap_header,
+)
+
+
 log = logging.getLogger(__name__)
 NUM2FMT = {1: "B", 2: "H", 4: "I", 8: "Q"}
 
@@ -476,6 +484,24 @@ def pal_MsgSendTo(self, cpustate, tb, hook):
             qid,
             itemType,
         )
+    
+    msg_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msgAddr, 4), "little"
+    )
+
+    msgGroup = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msgAddr+6, 2), "little"
+    )
+
+    msg_id_lte_pdcp_data_ind = self.symbol_table.lookup("MSG_ID_LTE_PDCP_DATA_IND").address
+    msg_id_lte_pdcp_data_req = self.symbol_table.lookup("MSG_ID_LTE_PDCP_DATA_REQ").address
+
+    if(msg_id == msg_id_lte_pdcp_data_ind):
+        dump_inbound_rrc_data(self, cpustate, msgAddr)
+      
+   
+    elif(msg_id == msg_id_lte_pdcp_data_req):
+        dump_outbound_rrc_data(self, cpustate, msgAddr)
 
 
 def pal_QueueCreate(self, cpustate, tb, hook):
@@ -527,6 +553,91 @@ def protect_write_access(self, cpustate, memory_access_desc, label=None, const_v
         f"Protected write access: PC({cpustate.panda_guest_pc:#010x}) Addr({addr:#010x})" +
         (f" ({label}+{offset:#x})" if label else "") + f" Value({value:#x})"
     )
+
+### GSM-TAP features ###
+
+# Print uplink RRC data
+def dump_outbound_rrc_data(self, cpustate, msg_struct_addr):
+    msg_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr, 4), "little"
+    )
+    
+    msg_id_lte_pdcp_data_req = self.symbol_table.lookup("MSG_ID_LTE_PDCP_DATA_REQ").address
+
+    assert (
+        msg_id == msg_id_lte_pdcp_data_req
+    ), f"Tried to extract a data buffer from wrong msg type (is: {msg_id}, expected: MSG_ID_LTE_PDCP_DATA_REQ ({msg_id_lte_pdcp_data_req})"
+  
+    data_ptr = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 12, 4), "little"
+    )
+    data_len = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 8, 4), "little"
+    )
+    log_emit(self, cpustate, "\033[92mSending outbound RRC->PDCP DCCH data at %04X for %02X bytes\033[0m",
+        data_ptr,
+        data_len)
+   
+    gsmtap_hdr = create_gsmtap_header(
+        payload_type=gsmtap_type.LTE_RRC, sub_type=gsmtap_lte_rrc_types.UL_DCCH
+    )
+    send_gsmtap_packet(
+        self, gsmtap_hdr, self.qemu.pypanda.physical_memory_read(data_ptr, data_len)
+)
+
+# Print Downlink RRC data
+def dump_inbound_rrc_data(self, cpustate, msg_struct_addr):
+
+    msg_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr, 2), "little"
+    )
+    
+    msg_id_lte_pdcp_data_ind = self.symbol_table.lookup("MSG_ID_LTE_PDCP_DATA_IND").address
+
+    assert (
+        msg_id == msg_id_lte_pdcp_data_ind
+    ), f"Tried to extract a data buffer from wong ilm msg type (is: ${msg_id}, expected: MSG_ID_LTE_PDCP_DATA_IND ({lte_pdcp_data_ind_msg_id}))"
+    
+
+    data_ptr = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 16, 4), "little"
+    )
+    data_len = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 12, 4), "little"
+    )
+    
+    rb_id = int.from_bytes(
+        self.qemu.pypanda.physical_memory_read(msg_struct_addr + 8, 4), 'little')
+    
+    if(rb_id == 0x2):
+        log_emit(self, cpustate,
+            "\033[92mReceived inbound RRC->PDCP DCCH data at %04X for %02X bytes\033[0m",
+            data_ptr,
+            data_len
+        )
+
+        gsmtap_hdr = create_gsmtap_header(
+            payload_type=gsmtap_type.LTE_RRC, sub_type=gsmtap_lte_rrc_types.DL_DCCH
+        )
+        send_gsmtap_packet(
+            self, gsmtap_hdr, self.qemu.pypanda.physical_memory_read(data_ptr, data_len)
+        )
+    
+    elif(rb_id == 0x12):
+        
+        log_emit(self, cpustate,
+            "\033[92mReceived inbound RRC->PDCP BCCH data at %04X for %02X bytes\033[0m",
+            data_ptr,
+            data_len
+        )
+
+        gsmtap_hdr = create_gsmtap_header(
+            payload_type=gsmtap_type.LTE_RRC, sub_type=gsmtap_lte_rrc_types.BCCH_DL_SCH
+        )
+        send_gsmtap_packet(
+            self, gsmtap_hdr, self.qemu.pypanda.physical_memory_read(data_ptr, data_len)
+        )
+
 
 ###############################
 

--- a/firmwire/vendor/shannon/hooks.py
+++ b/firmwire/vendor/shannon/hooks.py
@@ -596,7 +596,7 @@ def dump_inbound_rrc_data(self, cpustate, msg_struct_addr):
 
     assert (
         msg_id == msg_id_lte_pdcp_data_ind
-    ), f"Tried to extract a data buffer from wong ilm msg type (is: ${msg_id}, expected: MSG_ID_LTE_PDCP_DATA_IND ({lte_pdcp_data_ind_msg_id}))"
+    ), f"Tried to extract a data buffer from wong ilm msg type (is: ${msg_id}, expected: MSG_ID_LTE_PDCP_DATA_IND ({msg_id_lte_pdcp_data_ind}))"
     
 
     data_ptr = int.from_bytes(

--- a/firmwire/vendor/shannon/pattern.py
+++ b/firmwire/vendor/shannon/pattern.py
@@ -154,6 +154,20 @@ PATTERNS_CORTEX_R = {
         "post_lookup": handlers.get_dsp_sync1,
         "required": False,
     },
+    # Look for "LTE_PDCP_DATA_IND malloc fail"
+    "MSG_ID_LTE_PDCP_DATA_IND" : {
+        "pattern": [
+            "0420 ???????? ???? ???????? 0cf0???? ??90 ???? ??21 0160",
+            "???????? 0420 ???????? 0cf0???? ??90 0028 ???? ??21 0160"
+        ],
+        "offset": 20,
+        "post_lookup": handlers.find_msg_id_lte_pdcp_data_ind,
+        "required": False
+    },
+    "MSG_ID_LTE_PDCP_DATA_REQ" : {
+        "lookup": handlers.find_msg_id_lte_pdcp_data_req,
+        "required": False
+    },
 }
 
 PATTERNS_CORTEX_A = {

--- a/firmwire/vendor/shannon/pattern_handlers.py
+++ b/firmwire/vendor/shannon/pattern_handlers.py
@@ -765,11 +765,11 @@ def find_msg_id_lte_pdcp_data_req(data, offset):
 
         if((ins >> 11) == 0x14):
             # adr
-            target = res[0] + 4 + 4 * (ins & 0xFF) + res[0]
+            target = res[0] + 4 + 4 * (ins & 0xFF)
         
         elif((ins >> 11) == 0x9):
             # pc relative ldr
-            target = ((res[0] + 4) & ~3) + 4*(ins & 0xFF)
+            target = res[0] + 4 + 4 * (ins & 0xFF)
         
         
         if(target in llocs):

--- a/firmwire/vendor/shannon/pattern_handlers.py
+++ b/firmwire/vendor/shannon/pattern_handlers.py
@@ -728,7 +728,7 @@ def find_msg_id_lte_pdcp_data_req(data, offset):
     
     # Not the cleanest pattern, but search for code that
     # prepares an LTE_PDCP_DATA_REQ message, using an `adr` 
-    # instruction
+    # or `ldr` instruction
 
     bp = BinaryPattern("msg_id_lte_pdcp_data_req")
     bp.from_str(b"LTE_PDCP_DATA_REQ\x00")
@@ -759,7 +759,6 @@ def find_msg_id_lte_pdcp_data_req(data, offset):
         if res is None:
             break
         
-        # adr instruction
         ins = int.from_bytes(data[res[0]:res[0]+2], "little")
         
         target = 0

--- a/firmwire/vendor/shannon/pattern_handlers.py
+++ b/firmwire/vendor/shannon/pattern_handlers.py
@@ -711,3 +711,75 @@ def get_dsp_sync1(self, sym, data, offset):
     self.symbol_table.add(sym.name, sync_word)
     log.info(f"Retrieved sync word 1: {sync_word}")
     return True
+
+
+def find_msg_id_lte_pdcp_data_ind(self, sym, data, offset):
+    main_toc = self.modem_file.get_section("MAIN")
+    val = int.from_bytes(
+        main_toc.data[sym.address - main_toc.load_address: sym.address - main_toc.load_address + 4], "little"
+    )
+    val = val & 0xFF
+    self.symbol_table.remove(sym.name)
+    self.symbol_table.add(sym.name, val)
+    log.info(f"Resolved MSG_ID_LTE_PDCP_DATA_IND to : {val:#x}")
+    return True
+
+def find_msg_id_lte_pdcp_data_req(data, offset):
+    
+    # Not the cleanest pattern, but search for code that
+    # prepares an LTE_PDCP_DATA_REQ message, using an `adr` 
+    # instruction
+
+    bp = BinaryPattern("msg_id_lte_pdcp_data_req")
+    bp.from_str(b"LTE_PDCP_DATA_REQ\x00")
+
+    locs = []
+    llocs = []
+    npos = 0
+
+
+    # LTE_PDCP_DATA_REQ strings
+    locs = [l[0] for l in bp.findall(data)]
+    llocs += locs
+
+    # pointers to string
+
+    for l in locs:
+        bp_x = BinaryPattern("xref")
+        bp_x.from_str(struct.pack("I", l+offset))
+        rez = bp_x.findall(data, maxresults=10)
+        for r in rez:
+            llocs.append(r[0])
+
+    bp_code = BinaryPattern("bp_code", offset=0x4)
+    bp_code.from_hex("??20 ??60 ???? ??61")
+
+    while True:
+        res = bp_code.find(data, pos=npos)
+        if res is None:
+            break
+        
+        # adr instruction
+        ins = int.from_bytes(data[res[0]:res[0]+2], "little")
+        
+        target = 0
+
+        if((ins >> 11) == 0x14):
+            # adr
+            target = res[0] + 4 + 4 * (ins & 0xFF) + res[0]
+        
+        elif((ins >> 11) == 0x9):
+            # pc relative ldr
+            target = ((res[0] + 4) & ~3) + 4*(ins & 0xFF)
+        
+        
+        if(target in llocs):
+            # +0x18 is the type: LTE_PDCP_DATA_REQ
+            # +0x8  is the message id == ??20 ??60
+            # Probably 0xc2
+            val = int.from_bytes(data[res[0]-0x4:res[0]-0x4+0x2], "little") & 0xFF
+            log.info(f"Resolved LTE_PDCP_DATA_REQ to : {val:#x}")
+            return val
+        
+        npos = res[1]
+    

--- a/firmwire/vendor/shannon/pattern_handlers.py
+++ b/firmwire/vendor/shannon/pattern_handlers.py
@@ -778,7 +778,7 @@ def find_msg_id_lte_pdcp_data_req(data, offset):
             # +0x8  is the message id == ??20 ??60
             # Probably 0xc2
             val = int.from_bytes(data[res[0]-0x4:res[0]-0x4+0x2], "little") & 0xFF
-            log.info(f"Resolved LTE_PDCP_DATA_REQ to : {val:#x}")
+            log.info(f"Resolved MSG_ID_LTE_PDCP_DATA_REQ to : {val:#x}")
             return val
         
         npos = res[1]


### PR DESCRIPTION
This PR contains the gsmtap features introduced in PR #48 for Shannon Cortex R basebands. It adds:

- Patterns and pattern handlers for LTE_RRC_PDCP message types.
- Hooks for pal_MsgSendTo to filter out LTE_RRC_PDCP messages. Currently we only support Downlink and Uplink DCCH messages with experimental support for DL BCCH messages.

The patterns and hooks are tested on the following baseband images: CP_G970FXXSGHWC2 (Samsung Galaxy S10e), CP_G960FXXS7CSJ3 (Samsung Galaxy S9) and XT1970-3_KANE_RETEU_11_RSA31.Q1-48-36-23 (Motorola One Vision).
