### PR TITLE
Fix Docker build: pytest 8 compatibility and pin panda commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,15 @@ RUN apt-get update && apt-get upgrade -y && \
   
 # Install panda, and deps for Shannon Panda
 WORKDIR /firmwire_deps
+# Pin panda to the exact commit verified to build against this FirmWire release.
+# Upstream panda 'main' is a from-source QEMU fork and is the main moving target
+# for build reproducibility; pinning avoids surprise breakage. Bump to re-pin.
+ARG PANDA_COMMIT=03098aef47dafbd8fdc62fb3ff68db47a3ca8cab
 RUN rm -rf panda \
   && git clone --depth=1 https://github.com/FirmWire/panda.git \
   && cd panda \
-  && git checkout main \
+  && git fetch --depth=1 origin ${PANDA_COMMIT} \
+  && git checkout ${PANDA_COMMIT} \
   && rm -rf build \
   && mkdir build \
   && cd build \

--- a/tests/test_vendor_basic.py
+++ b/tests/test_vendor_basic.py
@@ -9,7 +9,7 @@ from firmwire.util.misc import download_url
 SHANNON_MODEM_URL = 'https://github.com/grant-h/ShannonFirmware/raw/master/modem_files/CP_G973FXXS5CTD1_CP15661447_CL18242812_QB30535823_REV01_user_low_ship.tar.md5.lz4'
 MTK_MODEM_URL = 'https://zenodo.org/record/6516030/files/CP_A415FXXU1ATE1_CP15883562_CL18317596_QB31188168_REV00_user_low_ship_MULTI_CERT.tar.md5?download=1'
 
-def setup():
+def setup_module(module=None):
     global SHANNON_MODEM_FILE, MTK_MODEM_FILE
     MTK_MODEM_FILE = download_url(MTK_MODEM_URL)
     SHANNON_MODEM_FILE = download_url(SHANNON_MODEM_URL)


### PR DESCRIPTION
## Summary

The repo no longer builds and tests cleanly out of the box on a current Docker
host. Two small, targeted fixes restore a green build and the full CI chain.

## Changes

### `tests/`: pytest 8 compatibility
The Dockerfile installs the latest `pytest` (8.x), which removed nose-style
module-level `setup()`. As a result the `setup()` in
`tests/test_vendor_basic.py` was never called, the modem fixtures were never
downloaded, and both vendor tests failed with
`NameError: name 'SHANNON_MODEM_FILE' is not defined`. Renaming `setup()` to
`setup_module()` uses pytest's xunit-style hook (still supported) and preserves
the original download-once behavior.

### `Dockerfile`: pin panda to a known-good commit
`git clone … && git checkout main` of `FirmWire/panda` (a from-source QEMU fork)
is the main build-reproducibility risk: upstream `main` can move and break the
build. Pin to the commit verified to build
(`03098aef47dafbd8fdc62fb3ff68db47a3ca8cab`) via an `ARG` + shallow fetch-by-sha,
which keeps the clone fast and the pin easy to bump.

## Verification
Built from a clean `ubuntu:20.04` Docker host; all four CI steps pass:
- `docker build -t firmwire:latest .`
- `./firmwire.py --help`
- `make -C modkit/`
- `pytest --forked tests/` — 2 passed (Shannon SM-G973F and MTK A415F firmware boot and `run_for(5)`)

No changes to `requirements.txt` were required.
