### PR TITLE
FIX: drain CP->PHY IPC ring to avoid PHY_IPC_C2P_Sender assert

### DIFF
--- a/firmwire/vendor/shannon/machine.py
+++ b/firmwire/vendor/shannon/machine.py
@@ -810,6 +810,21 @@ r12: %08x     cpsr: %08x""" % (
             dsp_periph.dsp_sync0 = self.symbol_table.lookup("DSP_SYNC_WORD_0").address
             dsp_periph.dsp_sync1 = self.symbol_table.lookup("DSP_SYNC_WORD_1").address
 
+        # Tell the PhyIpc doorbell peripheral where the CP->PHY ring lives so it
+        # can model the (un-emulated) PHY draining it. Without this the ring
+        # fills and PHY_IPC_C2P_Sender asserts `actFlag == FLAG_CLEAR`.
+        sym_phy_base = self.symbol_table.lookup("SYM_PHY_IPC_C2P_RING_BASE")
+        if sym_phy_base is not None and "PhyIpc" in self.peripheral_map:
+            self.peripheral_map["PhyIpc"].ring_base = sym_phy_base.address
+            log.info(
+                "PhyIpc: CP->PHY ring base = %#010x", sym_phy_base.address
+            )
+        elif "PhyIpc" in self.peripheral_map:
+            log.warning(
+                "SYM_PHY_IPC_C2P_RING_BASE unresolved; PhyIpc drain disabled "
+                "(PHY_IPC_C2P_Sender may assert)"
+            )
+
         disable_list = []
 
         if self.modem_soc.name in ("S5000AP", "S5123AP", "S5133AP"):

--- a/firmwire/vendor/shannon/nr/hw/PhyIpcPeripheral.py
+++ b/firmwire/vendor/shannon/nr/hw/PhyIpcPeripheral.py
@@ -1,0 +1,69 @@
+## Copyright (c) 2022, Team FirmWire
+## SPDX-License-Identifier: BSD-3-Clause
+import struct
+
+from . import LoggingPeripheral
+
+
+class PhyIpcPeripheralCortexA(LoggingPeripheral):
+    """Models the (un-emulated) PHY/L1 DSP consuming the CP->PHY async IPC ring.
+
+    The CP queues a command into a 16-deep ring (per channel) via
+    PHY_IPC_C2P_Sender, marking each slot "pending" (actFlag = 0x01020304), then
+    rings this write-only doorbell to interrupt the PHY. On real hardware the PHY
+    consumes the slots, clears each actFlag back to FLAG_CLEAR (0) and advances
+    the consumer index. FirmWire does not emulate the PHY, so the ring is never
+    drained; after 16 sends on a channel the producer laps the consumer and the
+    sender fires `Dev Assert (actFlag == FLAG_CLEAR)` (PHY_IPC_C2P_Sender.c:63 /
+    L1_Exit.c:253), killing the run.
+
+    On any doorbell write we model instantaneous PHY consumption: for every
+    channel, clear all slot actFlags and set rdIdx := wrIdx.
+
+    Ring layout, relative to `ring_base` (= the value FUN_4128b7ec returns, i.e.
+    &SCATTERED_FROM_...; resolved per-image via the SYM_PHY_IPC_C2P_RING_BASE
+    pattern). The field offsets are compile-time constants, stable across builds
+    of this baseband generation:
+
+        slots  @ +0x11d68   NUM_SLOTS * SLOT_SIZE bytes, actFlag = first word
+        rdIdx  @ +0x12268   u16 per channel  (consumer / PHY)
+        wrIdx  @ +0x12272   u16 per channel  (producer / CP)
+
+    with channel stride CHAN_STRIDE.
+    """
+
+    SLOTS_OFF = 0x11D68
+    RDIDX_OFF = 0x12268
+    WRIDX_OFF = 0x12272
+    CHAN_STRIDE = 0x100
+    SLOT_SIZE = 0x10
+    NUM_SLOTS = 16
+    NUM_CHANNELS = 5
+
+    def __init__(self, name, address, size, **kwargs):
+        # Resolved after pattern matching (see machine.py); None disables drain.
+        self.ring_base = None
+        super().__init__(name, address, size, **kwargs)
+
+        self.read_handler[0:size] = self.hw_read
+        self.write_handler[0:size] = self.hw_write
+
+    def hw_write(self, offset, size, value):
+        if self.ring_base is not None:
+            self._drain_rings()
+        return super().hw_write(offset, size, value)
+
+    def _drain_rings(self):
+        base = self.ring_base
+        zero = struct.pack("<I", 0)
+        for ch in range(self.NUM_CHANNELS):
+            ch_off = ch * self.CHAN_STRIDE
+            for slot in range(self.NUM_SLOTS):
+                self.machine.physical_memory_write(
+                    base + self.SLOTS_OFF + ch_off + slot * self.SLOT_SIZE, zero
+                )
+            # consumer catches up to the producer (queue drained)
+            wr = self.machine.panda.physical_memory_read(
+                base + self.WRIDX_OFF + ch * 2, 2
+            )
+            self.machine.physical_memory_write(base + self.RDIDX_OFF + ch * 2, wr)

--- a/firmwire/vendor/shannon/nr/hw/__init__.py
+++ b/firmwire/vendor/shannon/nr/hw/__init__.py
@@ -3,6 +3,7 @@ from firmwire.hw.peripheral import *
 from .ClkPeripheral import *
 from .DSPPeripheral import DSPPeripheralCortexA
 from .ipc import GIPCPeripheral
+from .PhyIpcPeripheral import PhyIpcPeripheralCortexA
 from .MsiPeripheral import MsiPeripheral
 from .shannoncp import SHMPeripheralCortexA
 from .shannonsoc import ShannonSOCPeripheralCortexA

--- a/firmwire/vendor/shannon/nr/soc/__init__.py
+++ b/firmwire/vendor/shannon/nr/soc/__init__.py
@@ -34,6 +34,12 @@ class S5123(ShannonSOC):
             SOCPeripheral(MsiPeripheral,        0x15000000, 0x1000, name="MSI"),
             SOCPeripheral(Unknown7Peripheral,   0x10000000, 0x1000, name="UNK7"),
             SOCPeripheral(Unknown11Peripheral,  0x83050000, 0x1000, name="UNK11"),
+            SOCPeripheral(
+                PhyIpcPeripheralCortexA,
+                0xEF101000,  # page holding the CP->PHY C2P doorbell (0xEF101F00)
+                0x1000,
+                name="PhyIpc",
+            ),
         ]
 
 class S5123AP(ShannonSOC):
@@ -68,6 +74,12 @@ class S5123AP(ShannonSOC):
                 0x1000,
                 name="DSPPeripheral",
                 sync=[0xc1, 0x1bc],
+            ),
+            SOCPeripheral(
+                PhyIpcPeripheralCortexA,
+                0xEF101000,  # page holding the CP->PHY C2P doorbell (0xEF101F00)
+                0x1000,
+                name="PhyIpc",
             ),
         ]
 

--- a/firmwire/vendor/shannon/pattern.py
+++ b/firmwire/vendor/shannon/pattern.py
@@ -316,4 +316,27 @@ PATTERNS_CORTEX_A = {
         "lookup": handlers.find_counter,
         "soc_match": ["S5123", "S5123AP"],
     },
+    # PHY_IPC_C2P_Sender: recover the CP->PHY ring base, published as
+    # SYM_PHY_IPC_C2P_RING_BASE and consumed by the PhyIpc peripheral to drain
+    # the ring (see PhyIpcPeripheral.py). The two Cortex-A NR variants differ in
+    # how the sender loads the base, so each SoC family gets its own entry:
+    #
+    #  - S5123AP (e.g. G991B): base via a `bl` to a thunk. Pattern anchors on the
+    #    prologue + `add.w r5, r0, r4, lsl #8` bracketing that first bl; the
+    #    handler decodes bl -> thunk -> movw/movt.
+    #  - S5123 (e.g. oriole): base built inline as `movw rD / movt rD` in the
+    #    prologue (no call). Pattern wildcards the two immediate-bearing
+    #    instructions; the handler decodes them in place.
+    "PHY_IPC_C2P_Sender_thunked": {
+        "pattern": "2de9f04f 83b0 0e46 0446 ???????? 00eb0425",
+        "post_lookup": handlers.get_phy_ipc_c2p_ring_base_thunked,
+        "required": False,
+        "soc_match": ["S5123AP"],
+    },
+    "PHY_IPC_C2P_Sender_inline": {
+        "pattern": "2de9f04f 83b0 ???????? 0546 8846 ????????",
+        "post_lookup": handlers.get_phy_ipc_c2p_ring_base_inline,
+        "required": False,
+        "soc_match": ["S5123"],
+    },
 }

--- a/firmwire/vendor/shannon/pattern_handlers.py
+++ b/firmwire/vendor/shannon/pattern_handlers.py
@@ -581,6 +581,75 @@ def s5123_get_dsp_sync1(self, sym, data, offset):
     return True
 
 
+def _decode_thumb_bl(bl_addr, hw1, hw2):
+    """Decode a 32-bit Thumb BL/BLX (T1) at `bl_addr` to its absolute target."""
+    S = (hw1 >> 10) & 1
+    imm10 = hw1 & 0x3FF
+    J1 = (hw2 >> 13) & 1
+    J2 = (hw2 >> 11) & 1
+    imm11 = hw2 & 0x7FF
+    I1 = (~(J1 ^ S)) & 1
+    I2 = (~(J2 ^ S)) & 1
+    imm = (S << 24) | (I1 << 23) | (I2 << 22) | (imm10 << 12) | (imm11 << 1)
+    if S:
+        imm -= 1 << 25
+    return (bl_addr + 4 + imm) & 0xFFFFFFFF
+
+
+def _publish_phy_ipc_ring_base(self, base, detail):
+    """Publish SYM_PHY_IPC_C2P_RING_BASE (consumed by the PhyIpc peripheral)."""
+    self.symbol_table.set("SYM_PHY_IPC_C2P_RING_BASE", base)
+    log.info("PHY IPC C2P ring base: %#010x (%s)", base, detail)
+    return True
+
+
+def get_phy_ipc_c2p_ring_base_thunked(self, sym, data, offset):
+    """S5123AP (e.g. G991B): the ring base is loaded via a function call.
+
+    `sym` is PHY_IPC_C2P_Sender's entry. Its first `bl` (at +0xa: push / sub sp
+    / mov r6,r1 / mov r4,r0) calls a tiny thunk that returns the base via
+    `movw rD,#lo; movt rD,#hi`. Decode the bl to find the thunk, then its
+    immediates. The base is scatter-loaded RAM (per-build); the field offsets
+    used by the PhyIpc peripheral are compile-time constants.
+    """
+    fn = sym.address - offset
+    bl_off = fn + 0xA
+    if bl_off + 4 > len(data):
+        log.error("PHY_IPC_C2P_Sender bl out of section range")
+        return False
+    hw1, hw2 = struct.unpack("<HH", data[bl_off : bl_off + 4])
+    thunk = _decode_thumb_bl(sym.address + 0xA, hw1, hw2)
+
+    t = thunk - offset
+    if t < 0 or t + 8 > len(data):
+        log.error("PHY IPC base thunk %#010x outside section", thunk)
+        return False
+
+    movw = decode_movw(struct.unpack("<I", data[t : t + 4])[0])
+    movt = decode_movw(struct.unpack("<I", data[t + 4 : t + 8])[0])
+    base = (movt << 16) | movw
+    return _publish_phy_ipc_ring_base(
+        self, base, "sender %#010x, thunk %#010x" % (sym.address, thunk)
+    )
+
+
+def get_phy_ipc_c2p_ring_base_inline(self, sym, data, offset):
+    """S5123 (e.g. oriole): the ring base is loaded inline, no function call.
+
+    `sym` is PHY_IPC_C2P_Sender's entry. The base is built directly in the
+    prologue as `movw rD,#lo` (at +0x6) and `movt rD,#hi` (at +0xe), bracketing
+    the `mov r5,r0; mov r8,r1` arg saves. Decode those two immediates.
+    """
+    fn = sym.address - offset
+    if fn + 0x12 > len(data):
+        log.error("PHY_IPC_C2P_Sender inline movw/movt out of section range")
+        return False
+    movw = decode_movw(struct.unpack("<I", data[fn + 0x6 : fn + 0xA])[0])
+    movt = decode_movw(struct.unpack("<I", data[fn + 0xE : fn + 0x12])[0])
+    base = (movt << 16) | movw
+    return _publish_phy_ipc_ring_base(self, base, "sender %#010x, inline" % sym.address)
+
+
 def find_task_table(data, offset):
     bp_task = BinaryPattern("task", offset=1)
     bp_task.from_str(b"\x00" + TASK_NAME_TO_FIND + b"\x00")


### PR DESCRIPTION
FirmWire does not emulate the PHY/L1 DSP, so the CP->PHY async IPC ring is never consumed; after 16 sends on a channel the producer laps the consumer and PHY_IPC_C2P_Sender fires Dev Assert (actFlag == FLAG_CLEAR) (L1_Exit.c:253), killing Cortex-A NR (S5123/S5123AP) runs.

Add PhyIpcPeripheralCortexA at the C2P doorbell page (0xEF101000) that models instant PHY consumption on each doorbell write: clear all slot actFlags and set rdIdx := wrIdx for all 5 channels. The ring base is resolved per-image via the pattern DB (SYM_PHY_IPC_C2P_RING_BASE) with two soc-gated PHY_IPC_C2P_Sender patterns: S5123AP loads the base via a bl to a thunk, S5123 (oriole) loads it inline (movw/movt).

Verified on G991B (S5123AP) and oriole (S5123): no assert, C2P ring depth stays at 0/16.

This PR fixes #61.